### PR TITLE
Guard SSL cleanup against null pointers

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -93,16 +93,17 @@ SecureSocket::close()
 void SecureSocket::freeSSLResources()
 {
     std::lock_guard<std::mutex> ssl_lock{ssl_mutex_};
+    if (m_ssl) {
+        if (m_ssl->m_ssl) {
+            SSL_shutdown(m_ssl->m_ssl);
+            SSL_free(m_ssl->m_ssl);
+            m_ssl->m_ssl = nullptr;
+        }
 
-    if (m_ssl->m_ssl != nullptr) {
-        SSL_shutdown(m_ssl->m_ssl);
-        SSL_free(m_ssl->m_ssl);
-        m_ssl->m_ssl = nullptr;
-    }
-
-    if (m_ssl->m_context != nullptr) {
-        SSL_CTX_free(m_ssl->m_context);
-        m_ssl->m_context = nullptr;
+        if (m_ssl->m_context) {
+            SSL_CTX_free(m_ssl->m_context);
+            m_ssl->m_context = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Guard `SecureSocket::freeSSLResources` with null checks for `m_ssl` and its members
- Allow destructor and `close()` to call cleanup safely when SSL wasn't initialized

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_b_68a518df03948325aa282d662596b3d2