### PR TITLE
Guard removeDoubleQuotes for short strings

### DIFF
--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -524,7 +524,8 @@ bool ArgParser::searchDoubleQuotes(std::string& command, size_t& left, size_t& r
 void ArgParser::removeDoubleQuotes(std::string& arg)
 {
     // if string is surrounded by double quotes, remove them
-    if (arg[0] == '\"' &&
+    if (arg.size() >= 2 &&
+        arg[0] == '\"' &&
         arg[arg.size() - 1] == '\"') {
         arg = arg.substr(1, arg.size() - 2);
     }

--- a/src/test/unittests/inputleap/ArgParserTests.cpp
+++ b/src/test/unittests/inputleap/ArgParserTests.cpp
@@ -223,4 +223,20 @@ TEST(ArgParserTests, assembleCommand_stringArrayWithSpace_returnCommand)
     EXPECT_EQ("\"stub1 space\" stub2 \"stub3 space\"", command);
 }
 
+TEST(ArgParserTests, removeDoubleQuotes_emptyString_noChange)
+{
+    std::string arg;
+    ArgParser::removeDoubleQuotes(arg);
+
+    EXPECT_TRUE(arg.empty());
+}
+
+TEST(ArgParserTests, removeDoubleQuotes_singleDoubleQuote_noChange)
+{
+    std::string arg = "\"";
+    ArgParser::removeDoubleQuotes(arg);
+
+    EXPECT_EQ("\"", arg);
+}
+
 } // namespace inputleap


### PR DESCRIPTION
## Summary
- Prevent ArgParser::removeDoubleQuotes from accessing invalid indices by requiring at least two characters.
- Verify behavior with new unit tests for empty and single-quote arguments.

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF`
- `cmake --build build --target unittests`
- `./build/bin/unittests`


------
https://chatgpt.com/codex/tasks/task_b_68a518e100588325a3fa8b2995dfa411