### PR TITLE
Fix regex search in release artifact helper

### DIFF
--- a/dist/scripts/download_release.py
+++ b/dist/scripts/download_release.py
@@ -20,7 +20,7 @@ def get_all_workflow_artifacts(s, run_id):
 
 def find_by_re(items, regex):
     for i in items:
-        if re.match(regex, i) is not None:
+        if re.search(regex, i) is not None:
             return i
     return None
 


### PR DESCRIPTION
## Summary
- ensure artifact matching searches entire path in download_release script

## Testing
- `python -m py_compile dist/scripts/download_release.py`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6"...)*

------
https://chatgpt.com/codex/tasks/task_b_68a515985e488325b8837d7ef895a612