### PR TITLE
Handle malformed drag info and add unit test

### DIFF
--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -45,30 +45,35 @@ void DragInformation::parseDragInfo(DragFileList& dragFileList, std::uint32_t fi
     std::uint32_t index = 0;
     while (index < fileNum) {
         findResult1 = data.find(',', startPos);
-        findResult2 = data.find_last_of(slash, findResult1);
-
-        if (findResult1 == startPos) {
-            //TODO: file number does not match, something goes wrong
+        if (findResult1 == std::string::npos || findResult1 == startPos) {
+            // malformed input or file number does not match
             break;
         }
 
+        findResult2 = data.find_last_of(slash, findResult1);
+        size_t filenameStart = (findResult2 == std::string::npos) ? 0 : findResult2 + 1;
+
         // set filename
-        if (findResult1 - findResult2 > 1) {
-            auto filename = data.substr(findResult2 + 1, findResult1 - findResult2 - 1);
+        if (findResult1 > filenameStart) {
+            auto filename = data.substr(filenameStart, findResult1 - filenameStart);
             DragInformation di;
             di.setFilename(filename);
             dragFileList.push_back(di);
         }
         startPos = findResult1 + 1;
 
-        //set filesize
+        // set filesize
         findResult2 = data.find(',', startPos);
-        if (findResult2 - findResult1 > 1) {
-            auto filesize = data.substr(findResult1 + 1, findResult2 - findResult1 - 1);
+        if (findResult2 == std::string::npos) {
+            // malformed input
+            break;
+        }
+        if (findResult2 > startPos) {
+            auto filesize = data.substr(startPos, findResult2 - startPos);
             size_t size = stringToNum(filesize);
             dragFileList.at(index).setFilesize(size);
         }
-        startPos = findResult1 + 1;
+        startPos = findResult2 + 1;
 
         ++index;
     }

--- a/src/test/unittests/inputleap/DragInformationTests.cpp
+++ b/src/test/unittests/inputleap/DragInformationTests.cpp
@@ -1,0 +1,39 @@
+/*
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2013-2016 Symless Ltd.
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "inputleap/DragInformation.h"
+
+#include <gtest/gtest.h>
+
+namespace inputleap {
+
+TEST(DragInformationTests, parseDragInfo_multipleFiles_parsedOnce)
+{
+    DragFileList files;
+    std::string data = "dir1/file1.txt,10,dir2/file2.txt,20,";
+
+    DragInformation::parseDragInfo(files, 2, data);
+
+    ASSERT_EQ(2u, files.size());
+    EXPECT_EQ("file1.txt", files.at(0).getFilename());
+    EXPECT_EQ(10u, files.at(0).getFilesize());
+    EXPECT_EQ("file2.txt", files.at(1).getFilename());
+    EXPECT_EQ(20u, files.at(1).getFilesize());
+}
+
+} // namespace inputleap
+


### PR DESCRIPTION
## Summary
- Ensure DragInformation::parseDragInfo stops when data is malformed and advances to the next entry correctly
- Add unit test verifying multiple drag files are parsed once each

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF`
- `cmake --build build --target unittests`
- `cd build && ctest -R unittests --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68a559fba5148325a574fa2421cd5f4f