### PR TITLE
Use thread-safe strerror and add concurrent test

### DIFF
--- a/src/lib/arch/unix/XArchUnix.cpp
+++ b/src/lib/arch/unix/XArchUnix.cpp
@@ -18,14 +18,34 @@
 
 #include "arch/unix/XArchUnix.h"
 
+#include <cerrno>
 #include <cstring>
+#include <string>
 
 namespace inputleap {
 
 std::string error_code_to_string_errno(int err)
 {
-    // FIXME -- not thread safe
-    return std::strerror(err);
+    char buffer[256];
+
+#if defined(__STDC_LIB_EXT1__)
+    // C11's thread-safe strerror
+    if (strerror_s(buffer, sizeof(buffer), err) != 0) {
+        return std::string();
+    }
+    return std::string(buffer);
+#else
+#if defined(_GNU_SOURCE) && defined(__GLIBC__)
+    // GNU-specific strerror_r returns a char*
+    return std::string(strerror_r(err, buffer, sizeof(buffer)));
+#else
+    // POSIX strerror_r returns 0 on success
+    if (strerror_r(err, buffer, sizeof(buffer)) != 0) {
+        buffer[0] = '\0';
+    }
+    return std::string(buffer);
+#endif
+#endif
 }
 
 } // namespace inputleap

--- a/src/test/unittests/base/ErrorStringTests.cpp
+++ b/src/test/unittests/base/ErrorStringTests.cpp
@@ -1,0 +1,60 @@
+/*
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2024
+ *
+ * This package is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * found in the file LICENSE that should have accompanied this file.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#if defined(UNIX)
+
+#include "arch/unix/XArchUnix.h"
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+using namespace inputleap;
+
+TEST(ErrorStringTests, thread_safety)
+{
+    std::vector<int> errors = {EINVAL, ENOENT, EPERM, E2BIG};
+    std::vector<std::string> expected;
+    expected.reserve(errors.size());
+    for (int e : errors) {
+        expected.emplace_back(std::strerror(e));
+    }
+
+    std::atomic<int> mismatches{0};
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < errors.size(); ++i) {
+        threads.emplace_back([&, i]() {
+            for (int j = 0; j < 1000; ++j) {
+                if (error_code_to_string_errno(errors[i]) != expected[i]) {
+                    ++mismatches;
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(0, mismatches.load());
+}
+
+#endif // defined(UNIX)


### PR DESCRIPTION
## Summary
- Implement thread-safe `error_code_to_string_errno` using `strerror_s` or the GNU/POSIX `strerror_r` variants
- Add multithreaded unit test ensuring concurrent calls yield correct, isolated messages

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF`
- `cmake --build build -j 8`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_68a55a0e7f188325a0e79530b30043bd