### PR TITLE
Use Qt endian utilities in IpcClient and add tests

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -252,6 +252,7 @@ if(INPUTLEAP_BUILD_TESTS)
     set(GUI_TEST_SOURCE_FILES
         test/KeySequenceTests.cpp
         test/HotkeyTests.cpp
+        test/IpcClientTests.cpp
         test/main.cpp
     )
 

--- a/src/gui/src/IpcClient.cpp
+++ b/src/gui/src/IpcClient.cpp
@@ -110,12 +110,12 @@ void IpcClient::sendCommand(const QString& command, ElevateMode const elevate)
 
     std::string stdStringCommand = command.toStdString();
     const char* charCommand = stdStringCommand.c_str();
-    int length = static_cast<int>(strlen(charCommand));
+    quint32 length = static_cast<quint32>(strlen(charCommand));
 
     char lenBuf[4];
     intToBytes(length, lenBuf, 4);
     stream.writeRawData(lenBuf, 4);
-    stream.writeRawData(charCommand, length);
+    stream.writeRawData(charCommand, static_cast<int>(length));
 
     char elevateBuf[1];
     // Refer to enum ElevateMode documentation for why this flag is mapped this way
@@ -128,23 +128,3 @@ void IpcClient::handleReadLogLine(const QString& text)
     Q_EMIT readLogLine(text);
 }
 
-// TODO: qt must have a built in way of converting int to bytes.
-void IpcClient::intToBytes(int value, char *buffer, int size)
-{
-    if (size == 1) {
-        buffer[0] = value & 0xff;
-    }
-    else if (size == 2) {
-        buffer[0] = (value >> 8) & 0xff;
-        buffer[1] = value & 0xff;
-    }
-    else if (size == 4) {
-        buffer[0] = (value >> 24) & 0xff;
-        buffer[1] = (value >> 16) & 0xff;
-        buffer[2] = (value >> 8) & 0xff;
-        buffer[3] = value & 0xff;
-    }
-    else {
-        // TODO: other sizes, if needed.
-    }
-}

--- a/src/gui/src/IpcClient.h
+++ b/src/gui/src/IpcClient.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QAbstractSocket>
+#include <QtEndian>
 
 #include "ElevateMode.h"
 
@@ -43,7 +44,26 @@ public slots:
     void retryConnect();
 
 private:
-    void intToBytes(int value, char* buffer, int size);
+    static inline void intToBytes(quint64 value, char* buffer, int size)
+    {
+        switch (size) {
+        case 1:
+            buffer[0] = static_cast<char>(value & 0xff);
+            break;
+        case 2:
+            qToBigEndian<quint16>(static_cast<quint16>(value), reinterpret_cast<uchar*>(buffer));
+            break;
+        case 4:
+            qToBigEndian<quint32>(static_cast<quint32>(value), reinterpret_cast<uchar*>(buffer));
+            break;
+        case 8:
+            qToBigEndian<quint64>(static_cast<quint64>(value), reinterpret_cast<uchar*>(buffer));
+            break;
+        default:
+            Q_ASSERT(false);
+            break;
+        }
+    }
 
 private slots:
     void connected();

--- a/src/gui/test/IpcClientTests.cpp
+++ b/src/gui/test/IpcClientTests.cpp
@@ -1,0 +1,60 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) 2024
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define private public
+#include "../src/IpcClient.h"
+#undef private
+
+#include <gtest/gtest.h>
+#include <QtEndian>
+#include <limits>
+
+TEST(IpcClientTests, SerializesAndDeserializesBoundaryValues)
+{
+    struct TestCase { quint64 value; int size; };
+    const TestCase cases[] = {
+        {0u, 1}, {std::numeric_limits<quint8>::max(), 1},
+        {0u, 2}, {std::numeric_limits<quint16>::max(), 2},
+        {0u, 4}, {std::numeric_limits<quint32>::max(), 4},
+        {0u, 8}, {std::numeric_limits<quint64>::max(), 8},
+    };
+
+    char buffer[8];
+    for (const auto& c : cases) {
+        IpcClient::intToBytes(c.value, buffer, c.size);
+
+        quint64 result = 0;
+        switch (c.size) {
+        case 1:
+            result = static_cast<quint8>(buffer[0]);
+            break;
+        case 2:
+            result = qFromBigEndian<quint16>(reinterpret_cast<const uchar*>(buffer));
+            break;
+        case 4:
+            result = qFromBigEndian<quint32>(reinterpret_cast<const uchar*>(buffer));
+            break;
+        case 8:
+            result = qFromBigEndian<quint64>(reinterpret_cast<const uchar*>(buffer));
+            break;
+        default:
+            break;
+        }
+
+        EXPECT_EQ(result, c.value);
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace manual int-to-bytes conversion with Qt endian helpers supporting 1,2,4,8-byte unsigned values
- add unit tests for integer serialization boundaries

## Testing
- `cmake -S . -B build -G Ninja -DQT_DEFAULT_MAJOR_VERSION=5`
- `cmake --build build --target guiunittests -j 4`
- `cd build && ctest -R guiunittests --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68a55a05fdf08325bc33ecbdc8b05cec