### PR TITLE
Handle UTF-8 command line args on Windows

### DIFF
--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -28,6 +28,8 @@
 
 #ifdef WINAPI_MSWINDOWS
 #include <VersionHelpers.h>
+#include <shellapi.h>
+#include "common/win32/encoding_utilities.h"
 #endif
 
 namespace inputleap {
@@ -44,13 +46,51 @@ XArgvParserError::XArgvParserError(const char *fmt, ...) :
     message = std::string(buf);
 }
 
-Argv::Argv(int argc, const char* const* argv) :
-    // FIXME: we assume UTF-8 encoding, but on Windows this is not correct
-    m_exename(inputleap::fs::u8path(argv[0]).filename().u8string())
+Argv::Argv(int argc, const char* const* argv)
+#if !WINAPI_MSWINDOWS
+    : m_exename(inputleap::fs::u8path(argv[0]).filename().u8string())
+#endif
 {
-    for (int i = 1; i < argc; i++)
-        m_argv.push_back(argv[i]);
+#if WINAPI_MSWINDOWS
+    int wargc = 0;
+    LPWSTR* wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (wargv != nullptr) {
+        m_storage.reserve(wargc);
+        for (int i = 0; i < wargc; ++i) {
+            m_storage.push_back(win_wchar_to_utf8(wargv[i]));
+            if (i == 0) {
+                m_exename = inputleap::fs::u8path(m_storage.back()).filename().u8string();
+            }
+            else {
+                m_argv.push_back(m_storage.back().c_str());
+            }
+        }
+        LocalFree(wargv);
+    }
+#else
+    m_storage.reserve(argc);
+    for (int i = 1; i < argc; ++i) {
+        m_storage.emplace_back(argv[i]);
+        m_argv.push_back(m_storage.back().c_str());
+    }
+#endif
 }
+
+#if WINAPI_MSWINDOWS
+Argv::Argv(int argc, const wchar_t* const* argv)
+{
+    m_storage.reserve(argc);
+    for (int i = 0; i < argc; ++i) {
+        m_storage.push_back(win_wchar_to_utf8(argv[i]));
+        if (i == 0) {
+            m_exename = inputleap::fs::u8path(m_storage.back()).filename().u8string();
+        }
+        else {
+            m_argv.push_back(m_storage.back().c_str());
+        }
+    }
+}
+#endif
 
 const char*
 Argv::shift()
@@ -587,7 +627,6 @@ ArgParser::updateCommonArgs(Argv &argv)
 
 std::string ArgParser::parse_exename(const char* arg)
 {
-    // FIXME: we assume UTF-8 encoding, but on Windows this is not correct
     return inputleap::fs::u8path(arg).filename().u8string();
 }
 

--- a/src/lib/inputleap/ArgParser.h
+++ b/src/lib/inputleap/ArgParser.h
@@ -37,6 +37,9 @@ public:
 class Argv {
 public:
     Argv(int argc, const char* const* argv);
+#if WINAPI_MSWINDOWS
+    Argv(int argc, const wchar_t* const* argv);
+#endif
 
     // Return the next argument (excluding argv[0]) and remove it from the list
     const char* shift();
@@ -62,6 +65,7 @@ public:
 
 private:
     std::deque<const char*> m_argv;
+    std::vector<std::string> m_storage;
     std::string m_exename;
 };
 

--- a/src/test/unittests/inputleap/ArgParserTests.cpp
+++ b/src/test/unittests/inputleap/ArgParserTests.cpp
@@ -17,6 +17,9 @@
 
 #include "inputleap/ArgParser.h"
 #include "inputleap/ArgsBase.h"
+#if WINAPI_MSWINDOWS
+#include "common/win32/encoding_utilities.h"
+#endif
 
 #include <gtest/gtest.h>
 
@@ -238,5 +241,20 @@ TEST(ArgParserTests, removeDoubleQuotes_singleDoubleQuote_noChange)
 
     EXPECT_EQ("\"", arg);
 }
+
+#if WINAPI_MSWINDOWS
+TEST(ArgParserTests, parseUnicodeArgs)
+{
+    const wchar_t* argv[] = {L"stub", L"--name", L"\x65e5\x672c"};
+    Argv a(3, argv);
+
+    const char* optarg = nullptr;
+    auto result = a.shift("--name", nullptr, &optarg);
+
+    std::string expected = win_wchar_to_utf8(L"\x65e5\x672c");
+    EXPECT_STREQ("--name", result);
+    EXPECT_STREQ(expected.c_str(), optarg);
+}
+#endif
 
 } // namespace inputleap


### PR DESCRIPTION
## Summary
- Convert Windows command line arguments to UTF-8 using wide APIs and feed into `Argv`
- Support wide-character arguments in `Argv`
- Test Windows parsing of non-ASCII command line options

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_68a55a26a1d08325b8bfbd72da3d24b2