### PR TITLE
Fix alias removal iterator in removeScreen

### DIFF
--- a/src/lib/server/Config.cpp
+++ b/src/lib/server/Config.cpp
@@ -120,14 +120,14 @@ void Config::removeScreen(const std::string& name)
 	}
 
 	// remove aliases (and canonical name)
-    for (auto iter = m_nameToCanonicalName.begin(); iter != m_nameToCanonicalName.end(); ) {
-		if (iter->second == canonical) {
-			m_nameToCanonicalName.erase(iter++);
-		}
-		else {
-			++index;
-		}
-	}
+        for (auto iter = m_nameToCanonicalName.begin(); iter != m_nameToCanonicalName.end(); ) {
+                if (iter->second == canonical) {
+                        m_nameToCanonicalName.erase(iter++);
+                }
+                else {
+                        ++iter;
+                }
+        }
 }
 
 void


### PR DESCRIPTION
## Summary
- fix iterator increment when removing screen aliases

## Testing
- `cmake --build . --parallel`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_68a56b2d178083259a40a91109c48794