### PR TITLE
Close temporary config file on stop

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -834,15 +834,30 @@ void MainWindow::stop_cmd_app()
 
     set_connection_state(AppConnectionState::DISCONNECTED);
 
-    // HACK: deleting the object deletes the physical file, which is
-    // bad, since it could be in use by the Windows service!
-#if !defined(Q_OS_WIN)
-    delete m_pTempConfigFile;
-#endif
-    m_pTempConfigFile = nullptr;
+    cleanupTempConfigFile();
 
     // reset so that new connects cause auto-hide.
     m_AlreadyHidden = false;
+}
+
+void MainWindow::cleanupTempConfigFile()
+{
+    if (!m_pTempConfigFile)
+    {
+        return;
+    }
+
+#if defined(Q_OS_WIN)
+    // On Windows the file must be closed before deletion so that the
+    // underlying path can be removed without leaving a locked handle.
+    if (m_pTempConfigFile->isOpen())
+    {
+        m_pTempConfigFile->close();
+    }
+#endif
+
+    delete m_pTempConfigFile;
+    m_pTempConfigFile = nullptr;
 }
 
 void MainWindow::stopService()

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -164,6 +164,7 @@ public slots:
         void proofreadInfo();
         void windowStateChanged();
         void updateSSLFingerprint();
+        void cleanupTempConfigFile();
 
     private:
         std::unique_ptr<Ui::MainWindow> ui_;


### PR DESCRIPTION
## Summary
- add `cleanupTempConfigFile` to close and remove the temporary config file when stopping the command app
- ensure Windows closes file handles before deleting to avoid locked paths

## Testing
- `./clean_build.sh` *(fails: Could not find a package configuration file provided by "Qt6"* )

------
https://chatgpt.com/codex/tasks/task_b_68a570f4162483259b24decc947654ad