### PR TITLE
Fix CRLF log splitting in MainWindow

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -393,9 +393,11 @@ void MainWindow::logOutput()
     {
         QString text(cmd_app_process_->readAllStandardOutput());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        const auto results = text.split(QRegularExpression("\r|\n|\r\n"));
+        const auto results = text.split(
+            QRegularExpression("\r\n|\n|\r"), Qt::SkipEmptyParts);
 #else
-        const auto results = text.split(QRegExp("\r|\n|\r\n"));
+        const auto results = text.split(
+            QRegExp("\r\n|\n|\r"), QString::SkipEmptyParts);
 #endif
         for (const auto& line : results) {
             if (!line.isEmpty())
@@ -435,9 +437,11 @@ void MainWindow::appendLogError(const QString& text)
 void MainWindow::appendLogRaw(const QString& text)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    const auto lines = text.split(QRegularExpression("\r|\n|\r\n"));
+    const auto lines = text.split(
+        QRegularExpression("\r\n|\n|\r"), Qt::SkipEmptyParts);
 #else
-    const auto lines = text.split(QRegExp("\r|\n|\r\n"));
+    const auto lines = text.split(
+        QRegExp("\r\n|\n|\r"), QString::SkipEmptyParts);
 #endif
     for (const auto& line : lines) {
         if (!line.isEmpty()) {


### PR DESCRIPTION
## Summary
- handle CRLF log output without blank lines
- skip empty parts when splitting raw log text

## Testing
- `./clean_build.sh` *(failed: build terminated early during compilation)*
- Compiled and ran a Qt snippet to verify CRLF line splitting

------
https://chatgpt.com/codex/tasks/task_b_68a578db1f44832582c8a21c3287bde5