### PR TITLE
Avoid manual quoting for profile dir

### DIFF
--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -621,7 +621,7 @@ void MainWindow::start_cmd_app()
     // launched the process (e.g. when launched with elevation). setting the
     // profile dir on launch ensures it uses the same profile dir is used
     // no matter how its relaunched.
-    args << "--profile-dir" << QString::fromStdString("\"" + inputleap::DataDirectories::profile().u8string() + "\"");
+    args << "--profile-dir" << QString::fromStdString(inputleap::DataDirectories::profile().u8string());
 #endif
 
     if ((app_role() == AppRole::Client && !clientArgs(args, app))


### PR DESCRIPTION
## Summary
- let QProcess handle quoting of the profile path by passing the raw profile directory

## Testing
- `cmake -S . -B build` (fails: missing XKB library)
- `cmake --build build -j2` (interrupted)
- `python - <<'PY'
from PyQt5.QtCore import QProcess, QCoreApplication
import sys
app = QCoreApplication([])
proc = QProcess()
path = 'C:/Program Files/Test Profile'
proc.start(sys.executable, ['-c', 'import sys;print("|".join(sys.argv[1:]))', '--profile-dir', path])
proc.waitForFinished()
output = bytes(proc.readAllStandardOutput()).decode()
print(output)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68a578cf60a88325857553db35260a7d