### PR TITLE
Handle connect failure in fake EIS socket

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -23,6 +23,7 @@
 
 #include <sys/un.h> // for EIS fd hack, remove
 #include <sys/socket.h> // for EIS fd hack, remove
+#include <unistd.h> // for close
 
 namespace inputleap {
 
@@ -111,6 +112,8 @@ int PortalInputCapture::fake_eis_fd()
     auto result = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
     if (result != 0) {
         LOG_DEBUG("Faked EIS fd failed: %s", strerror(errno));
+        close(fd);
+        return -1;
     }
 
     return sock;


### PR DESCRIPTION
## Summary
- close the temporary EIS socket on connection failure and signal errors to caller

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_b_68a5862dd6c08325aa8ed7eab82dffe9