### PR TITLE
Handle race when locking Motif clipboard

### DIFF
--- a/src/lib/platform/XWindowsClipboard.cpp
+++ b/src/lib/platform/XWindowsClipboard.cpp
@@ -635,30 +635,41 @@ XWindowsClipboard::icccmGetTime() const
     }
 }
 
-bool
-XWindowsClipboard::motifLockClipboard() const
-{
-    // fail if anybody owns the lock (even us, so this is non-recursive)
-    Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
-    if (lockOwner != None) {
-        LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
-        return false;
-    }
+bool XWindowsClipboard::motifLockClipboard() const {
+  // fail if anybody owns the lock (even us, so this is non-recursive)
+  Window lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
+  if (lockOwner != None) {
+    LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
+    return false;
+  }
 
-    // try to grab the lock
-    // FIXME -- is this right?  there's a race condition here --
-    // A grabs successfully, B grabs successfully, A thinks it
-    // still has the grab until it gets a SelectionClear.
-    Time time = XWindowsUtil::getCurrentTime(m_display, m_window);
-    m_impl->XSetSelectionOwner(m_display, m_atomMotifClipLock, m_window, time);
-    lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
-    if (lockOwner != m_window) {
-        LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
-        return false;
-    }
+  // try to grab the lock
+  Time time = XWindowsUtil::getCurrentTime(m_display, m_window);
+  m_impl->XSetSelectionOwner(m_display, m_atomMotifClipLock, m_window, time);
 
-    LOG_DEBUG1("locked motif clipboard");
-    return true;
+  // make sure the request has been processed and detect if another
+  // client stole the selection before we could confirm our lock
+  m_impl->XSync(m_display, False);
+
+  static auto predicate = [](Display *, XEvent *e, XPointer arg) -> Bool {
+    return (e->type == SelectionClear &&
+            e->xselectionclear.selection == reinterpret_cast<Atom>(arg));
+  };
+  XEvent event;
+  if (m_impl->XCheckIfEvent(m_display, &event, predicate,
+                            reinterpret_cast<XPointer>(m_atomMotifClipLock))) {
+    LOG_DEBUG1("motif lock lost due to competing owner");
+    return false;
+  }
+
+  lockOwner = m_impl->XGetSelectionOwner(m_display, m_atomMotifClipLock);
+  if (lockOwner != m_window) {
+    LOG_DEBUG1("motif lock owner 0x%08lx", lockOwner);
+    return false;
+  }
+
+  LOG_DEBUG1("locked motif clipboard");
+  return true;
 }
 
 void

--- a/src/test/unittests/platform/XWindowsClipboardLockTests.cpp
+++ b/src/test/unittests/platform/XWindowsClipboardLockTests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Tests for concurrent Motif clipboard locking
+ */
+
+#define private public
+#include "platform/XWindowsClipboard.h"
+#undef private
+#include "platform/XWindowsImpl.h"
+
+#undef None
+#undef Bool
+#include <atomic>
+#include <gtest/gtest.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+
+namespace inputleap {
+
+class XWindowsClipboardLockTests : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    pid = fork();
+    if (pid == 0) {
+      execlp("Xvfb", "Xvfb", ":99", "-screen", "0", "640x480x24", nullptr);
+      _exit(1);
+    }
+    sleep(1);
+    setenv("DISPLAY", ":99", 1);
+
+    impl = new XWindowsImpl();
+    display = impl->XOpenDisplay(nullptr);
+    ASSERT_NE(display, (Display *)0);
+
+    Window root = DefaultRootWindow(display);
+    window1 = XCreateSimpleWindow(display, root, 0, 0, 1, 1, 0, 0, 0);
+    window2 = XCreateSimpleWindow(display, root, 0, 0, 1, 1, 0, 0, 0);
+    clip1 = new XWindowsClipboard(impl, display, window1, kClipboardClipboard);
+    clip2 = new XWindowsClipboard(impl, display, window2, kClipboardClipboard);
+  }
+
+  static void TearDownTestSuite() {
+    delete clip1;
+    delete clip2;
+    XDestroyWindow(display, window1);
+    XDestroyWindow(display, window2);
+    impl->XCloseDisplay(display);
+    delete impl;
+    kill(pid, SIGTERM);
+    waitpid(pid, nullptr, 0);
+  }
+
+  static pid_t pid;
+  static XWindowsImpl *impl;
+  static Display *display;
+  static Window window1;
+  static Window window2;
+  static XWindowsClipboard *clip1;
+  static XWindowsClipboard *clip2;
+};
+
+pid_t XWindowsClipboardLockTests::pid;
+XWindowsImpl *XWindowsClipboardLockTests::impl;
+Display *XWindowsClipboardLockTests::display;
+Window XWindowsClipboardLockTests::window1;
+Window XWindowsClipboardLockTests::window2;
+XWindowsClipboard *XWindowsClipboardLockTests::clip1;
+XWindowsClipboard *XWindowsClipboardLockTests::clip2;
+
+TEST_F(XWindowsClipboardLockTests, ConcurrentLockAttempts) {
+  bool r1 = false;
+  bool r2 = false;
+  std::thread t1([&]() { r1 = clip1->motifLockClipboard(); });
+  std::thread t2([&]() { r2 = clip2->motifLockClipboard(); });
+  t1.join();
+  t2.join();
+
+  EXPECT_NE(r1, r2);
+
+  if (r1) {
+    clip1->motifUnlockClipboard();
+  }
+  if (r2) {
+    clip2->motifUnlockClipboard();
+  }
+}
+
+} // namespace inputleap


### PR DESCRIPTION
## Summary
- guard Motif clipboard lock by syncing and checking for SelectionClear events to detect competing owners
- add unit test spawning two clients to ensure only one wins the clipboard lock

## Testing
- `cmake --build build --target unittests`
- `cd build && CTEST_OUTPUT_ON_FAILURE=1 ctest -R unittests`


------
https://chatgpt.com/codex/tasks/task_b_68a58bd1f4d48325be12adbaedb91a82