### PR TITLE
Add explanatory comments to build scripts and entry sources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,17 @@
+# Root marker indicating this is the top-most EditorConfig file for the project
 root = true
 
+# Apply the following settings to all files
 [*]
+# Use Unix style line endings for cross-platform consistency
 end_of_line = lf
+# Enforce UTF-8 file encoding
 charset = utf-8
+# Automatically remove trailing spaces on save
 trim_trailing_whitespace = true
+# Ensure files end with a newline character
 insert_final_newline = true
+# Use spaces rather than tabs for indentation
 indent_style = space
+# Default indentation width of four spaces
 indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore temporary build files and development artifacts
 build_env.*
 config.h
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Primary build configuration for the Input Leap project. This file defines
+# global compiler settings, available build options, and orchestrates the
+# inclusion of all source modules.
+
 cmake_minimum_required(VERSION 3.21)
 project(InputLeap C CXX)
 
+# Toggleable features that allow developers to customize the build. Most are
+# enabled by default but can be overridden via the command line.
 option(INPUTLEAP_BUILD_GUI "Build the GUI" ON)
 option(INPUTLEAP_BUILD_TESTS "Build the tests" ON)
 option(INPUTLEAP_USE_EXTERNAL_GTEST "Use external installation of Google Test framework" OFF)
@@ -27,6 +33,7 @@ option(INPUTLEAP_BUILD_GULRAK_FILESYSTEM "Use internal filesystem library" OFF)
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
+# Place compiled binaries and libraries under a common build directory
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 

--- a/clean_build.ps1
+++ b/clean_build.ps1
@@ -1,5 +1,9 @@
 
-# The following packets need to be installed via Chocolatey in order to run this script:
+# Helper PowerShell script that performs a full clean build of Input Leap on
+# Windows. It ensures required dependencies are present, configures the build
+# environment, and invokes CMake to compile and package the application.
+
+# The following packages need to be installed via Chocolatey in order to run this script:
 # cmake, openssl, aqt (version 3.1.17), InnoSetup
 # Qt needs to be installed either manually or by running:
 # aqt install-qt windows desktop 6.4.2 win64_msvc2019_64 -O C:\Qt
@@ -7,8 +11,10 @@
 # aqt install-qt windows desktop 5.15.2 win64_msvc2019_64 -O C:\Qt
 # Note that Powershell may need to be restarted in order to changes to take effect.
 
+# Location where the Bonjour SDK will be extracted
 $bonjour_path = '.\deps\BonjourSDKLike'
 
+# Ensure dependency directory exists
 New-Item -Force -ItemType Directory -Path .\deps | Out-Null
 Invoke-WebRequest 'https://github.com/nelsonjchen/mDNSResponder/releases/download/v2019.05.08.1/x64_RelWithDebInfo.zip' -OutFile 'deps\BonjourSDKLike.zip' ;
 if (Test-Path -LiteralPath $bonjour_path) {
@@ -21,6 +27,7 @@ $bonjour_path = -join((Get-Location).Path, '\', $bonjour_path);
 Expand-Archive .\deps\BonjourSDKLike.zip -DestinationPath .\deps\BonjourSDKLike
 Remove-Item deps\BonjourSDKLike.zip
 
+# Possible Visual Studio install locations
 $vs_locations = @(
     @{version='Visual Studio 17 2022';
       path='C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat'},
@@ -50,6 +57,7 @@ if ($vs_version -eq '') {
 
 Write-Output "Using Visual Studio version $vs_version at $vs_path";
 
+# Determine build configuration, defaulting to Release
 $build_type = 'Release';
 if ($env:B_BUILD_TYPE -ne $null) {
     $build_type = $env:B_BUILD_TYPE;
@@ -68,6 +76,7 @@ if ($env:B_QT_ROOT -ne $null) {
 
 Write-Output "Using Qt at $qt_root";
 
+# Create a fresh build directory
 if (Test-Path -LiteralPath build) {
     Remove-Item -LiteralPath build -Recurse;
 }
@@ -76,6 +85,7 @@ pushd build
 
 try {
     $env:BONJOUR_SDK_HOME="$bonjour_path"
+    # Configure the project with CMake and specify the generator and platform
     cmake .. -G "$vs_version" -A x64 `
         "-DCMAKE_BUILD_TYPE=$build_type" `
         "-DCMAKE_PREFIX_PATH=$qt_root" `
@@ -83,6 +93,7 @@ try {
         -DDNSSD_LIB="$bonjour_path\Lib\x64\dnssd.lib" `
         -DCMAKE_INSTALL_PREFIX=input-leap-install
 
+    # Build and install the project using all available cores
     cmake --build . --parallel --config $build_type --target install
     ISCC /Qp installer-inno\input-leap.iss
 } finally {

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
+#
+# Convenience script to create a fresh build of Input Leap. The script
+# locates an appropriate CMake binary, prepares an isolated build
+# directory, and then compiles the project.
 
+# Ensure the working directory is the repository root so relative paths
+# behave as expected.
 cd "$(dirname "$0")" || exit 1
 
 # some environments have cmake v2 as 'cmake' and v3 as 'cmake3'
@@ -11,8 +17,13 @@ if [ -z "$B_CMAKE" ]; then
     exit 1
 fi
 
+# Default location for generated build files; can be overridden with
+# the B_BUILD_DIR environment variable.
 B_BUILD_DIR="${B_BUILD_DIR:-build}"
+# Build type defaults to Debug unless B_BUILD_TYPE is provided.
 B_BUILD_TYPE="${B_BUILD_TYPE:-Debug}"
+# Initial CMake flags used for configuration; callers may append more via
+# B_CMAKE_FLAGS.
 B_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=${B_BUILD_TYPE} ${B_CMAKE_FLAGS:-}"
 
 if [ "$(uname)" = "Darwin" ]; then
@@ -21,7 +32,7 @@ if [ "$(uname)" = "Darwin" ]; then
     B_CMAKE_FLAGS="${B_CMAKE_FLAGS} -DCMAKE_OSX_SYSROOT=$(xcrun --sdk macosx --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
 fi
 
-# Prefer ninja if available
+# Prefer the Ninja generator if it exists to speed up builds.
 if command -v ninja 2>/dev/null; then
     B_CMAKE_FLAGS="-GNinja ${B_CMAKE_FLAGS}"
 fi
@@ -34,10 +45,13 @@ set -e
 # Initialise Git submodules
 git submodule update --init --recursive
 
+# Remove any existing build directory to ensure a clean start
 rm -rf ${B_BUILD_DIR}
 mkdir ${B_BUILD_DIR}
 cd ${B_BUILD_DIR}
 echo "Starting Input Leap $B_BUILD_TYPE build in '${B_BUILD_DIR}'..."
+# Configure the project
 "$B_CMAKE" $B_CMAKE_FLAGS ..
+# Build using all available cores
 "$B_CMAKE" --build . --parallel
 echo "Build completed successfully"

--- a/src/client/MSWindowsClientTaskBarReceiver.cpp
+++ b/src/client/MSWindowsClientTaskBarReceiver.cpp
@@ -18,6 +18,10 @@
 
 #include "MSWindowsClientTaskBarReceiver.h"
 
+// Windows-specific taskbar integration for the client application. Handles
+// system tray icon updates and user interactions such as showing status or
+// exiting the client.
+
 #include "resource.h"
 #include "client/Client.h"
 #include "platform/MSWindowsClipboard.h"

--- a/src/client/input-leapc.cpp
+++ b/src/client/input-leapc.cpp
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Entry point for the client application which connects to an Input Leap
+// server to share mouse and keyboard input.
 #include "inputleap/ClientApp.h"
 #include "arch/Arch.h"
 #include "base/Log.h"
@@ -38,12 +40,15 @@ int client_main(int argc, char** argv)
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 #endif
 
+    // Initialize platform abstraction layer and core services
     Arch arch;
     arch.init();
 
+    // Logging and event handling infrastructure
     Log log;
     EventQueue events;
 
+    // Run the client application which communicates with the server
     ClientApp app(&events, createTaskBarReceiver);
     int result = app.run(argc, argv);
 #if SYSAPI_WIN32
@@ -59,5 +64,6 @@ int client_main(int argc, char** argv)
 
 int main(int argc, char** argv)
 {
+    // Delegate to namespaced entry point; keeps global namespace clean
     return inputleap::client_main(argc, argv);
 }

--- a/src/daemon/input-leapd.cpp
+++ b/src/daemon/input-leapd.cpp
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Entry point for the platform-specific daemon responsible for running
+// Input Leap as a background service.
 #include "inputleap/win32/DaemonApp.h"
 
 #include <iostream>
@@ -25,6 +27,7 @@
 int
 main(int argc, char** argv)
 {
+    // Initialize and run the daemon using standard argc/argv parameters
     inputleap::DaemonApp app;
     return app.run(argc, argv);
 }
@@ -36,6 +39,7 @@ main(int argc, char** argv)
 int WINAPI
 WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 {
+    // Windows entry point variant that uses global __argc/__argv values
     inputleap::DaemonApp app;
     return app.run(__argc, __argv);
 }

--- a/src/server/MSWindowsServerTaskBarReceiver.cpp
+++ b/src/server/MSWindowsServerTaskBarReceiver.cpp
@@ -18,6 +18,9 @@
 
 #include "MSWindowsServerTaskBarReceiver.h"
 
+// Implements the Windows-specific taskbar integration used by the server to
+// display status and allow quick user interaction from the system tray.
+
 #include "resource.h"
 #include "server/Server.h"
 #include "platform/MSWindowsClipboard.h"

--- a/src/server/input-leaps.cpp
+++ b/src/server/input-leaps.cpp
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Entry point for the server application which shares mouse and keyboard
+// events with connected clients.
 #include "inputleap/ServerApp.h"
 #include "arch/Arch.h"
 #include "base/Log.h"
@@ -45,12 +47,15 @@ int server_main(int argc, char** argv)
     setenv("OS_ACTIVITY_DT_MODE", "NO", true);
 #endif
 
+    // Initialize platform abstraction layer and core services
     Arch arch;
     arch.init();
 
+    // Logging and event dispatch infrastructure
     Log log;
     EventQueue events;
 
+    // Launch the main server application which manages client connections
     ServerApp app(&events, createTaskBarReceiver);
     int result = app.run(argc, argv);
 #if SYSAPI_WIN32
@@ -66,5 +71,7 @@ int server_main(int argc, char** argv)
 
 int main(int argc, char** argv)
 {
+    // Delegate to the namespaced server entry point to avoid polluting the
+    // global namespace and to keep parity with the client/daemon binaries.
     return inputleap::server_main(argc, argv);
 }


### PR DESCRIPTION
## Summary
- document editorconfig and gitignore usage
- annotate build scripts for clearer usage
- explain client, server, and daemon entry points and Windows taskbar helpers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_b_68a58eaaa4288325b349c02866f6f671