### PR TITLE
Use TLS methods and require TLS1.2

### DIFF
--- a/src/lib/net/SecureSocket.cpp
+++ b/src/lib/net/SecureSocket.cpp
@@ -387,20 +387,21 @@ SecureSocket::initContext(bool server)
         showSecureLibInfo();
     }
 
-    // SSLv23_method uses TLSv1, with the ability to fall back to SSLv3
     if (server) {
-        method = SSLv23_server_method();
+        method = TLS_server_method();
     }
     else {
-        method = SSLv23_client_method();
+        method = TLS_client_method();
     }
 
     // create new context from method
     SSL_METHOD* m = const_cast<SSL_METHOD*>(method);
     m_ssl->m_context = SSL_CTX_new(m);
 
-    // drop SSLv3 support
-    SSL_CTX_set_options(m_ssl->m_context, SSL_OP_NO_SSLv3);
+    // enforce TLS 1.2+ and drop older protocols
+    SSL_CTX_set_min_proto_version(m_ssl->m_context, TLS1_2_VERSION);
+    SSL_CTX_set_options(m_ssl->m_context,
+                        SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
 
     if (m_ssl->m_context == nullptr) {
         showError("");


### PR DESCRIPTION
## Summary
- replace deprecated SSLv23 methods with TLS server/client methods
- enforce TLS 1.2 minimum and disable SSLv3/TLSv1/TLSv1.1

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_b_68a64b74990c83259d71b28482623238