### PR TITLE
Fix drag info buffer allocation

### DIFF
--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -1790,17 +1790,18 @@ Server::sendDragInfo(BaseClientProxy* newScreen)
     std::string infoString;
     std::uint32_t fileCount = DragInformation::setupDragInfo(m_dragFileList, infoString);
 
-	if (fileCount > 0) {
-		char* info = nullptr;
-		size_t size = infoString.size();
-		info = new char[size];
-		memcpy(info, infoString.c_str(), size);
+    if (fileCount > 0) {
+        size_t size = infoString.size();
+        char* info = new char[size + 1];
+        memcpy(info, infoString.c_str(), size);
+        info[size] = '\0';
 
-		LOG_DEBUG2("sending drag information to client");
-		LOG_DEBUG3("dragging file list: %s", info);
-		LOG_DEBUG3("dragging file list string size: %zi", size);
-		newScreen->sendDragInfo(fileCount, info, size);
-	}
+        LOG_DEBUG2("sending drag information to client");
+        LOG_DEBUG3("dragging file list: %s", info);
+        LOG_DEBUG3("dragging file list string size: %zi", size);
+        newScreen->sendDragInfo(fileCount, info, size);
+        delete[] info;
+    }
 }
 
 void Server::onMouseMoveSecondary(std::int32_t dx, std::int32_t dy)


### PR DESCRIPTION
## Summary
- ensure drag info buffer includes null terminator and is freed after sending

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: Errors while running CTest; LastTest.log indicates all 59 tests passed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7feb3cdf48325bc396f465df0c04d