### PR TITLE
Handle portal input capture disable reasons with backoff

### DIFF
--- a/src/lib/platform/PortalInputCapture.cpp
+++ b/src/lib/platform/PortalInputCapture.cpp
@@ -26,6 +26,8 @@
 #include <unistd.h> // for close
 #include <cerrno> // for errno
 #include <cstring> // for strerror
+#include <algorithm>
+#include <string>
 
 namespace inputleap {
 
@@ -117,6 +119,40 @@ int PortalInputCapture::fake_eis_fd()
     }
 
     return fd;
+}
+
+bool PortalInputCapture::is_transient_disable(GVariant* options, std::string& reason)
+{
+    reason.clear();
+    bool transient = false;
+
+    if (options) {
+        GVariantIter iter;
+        const gchar* key;
+        GVariant* value;
+        g_variant_iter_init(&iter, options);
+        while (g_variant_iter_next(&iter, "{&sv}", &key, &value)) {
+            g_autofree gchar* val = g_variant_print(value, true);
+            LOG_DEBUG("disable option %s=%s", key, val);
+            if (std::strcmp(key, "reason") == 0 || std::strcmp(key, "error") == 0) {
+                const char* str = g_variant_get_string(value, nullptr);
+                reason = str ? str : "";
+                if (g_strcmp0(str, "timeout") == 0 || g_strcmp0(str, "error") == 0)
+                    transient = true;
+            }
+            g_variant_unref(value);
+        }
+    }
+
+    return transient;
+}
+
+unsigned int PortalInputCapture::next_backoff(unsigned int current_ms)
+{
+    const unsigned int kMaxDelay = 60000; // 60 seconds
+    if (current_ms == 0)
+        return 1000;
+    return std::min(current_ms * 2, kMaxDelay);
 }
 
 void PortalInputCapture::cb_session_closed(XdpSession* session)
@@ -274,16 +310,22 @@ void PortalInputCapture::cb_disabled(XdpInputCaptureSession* session, GVariant* 
     enabled_ = false;
     is_active_ = false;
 
-    // FIXME: need some better heuristics here of when we want to enable again
-    // But we don't know *why* we got disabled (and it's doubtfull we ever will), so
-    // we just assume that the zones will change or something and we can re-enable again
-    // ... very soon
-    g_timeout_add(1000,
-                  [](gpointer data) -> gboolean {
-                      reinterpret_cast<PortalInputCapture*>(data)->enable();
-                  return false;
-                  },
-                  this);
+    std::string reason;
+    bool transient = is_transient_disable(options, reason);
+
+    if (transient) {
+        LOG_DEBUG("Input capture disabled (%s); retrying in %u ms", reason.c_str(), reenable_delay_ms_);
+        g_timeout_add(reenable_delay_ms_,
+                      [](gpointer data) -> gboolean {
+                          reinterpret_cast<PortalInputCapture*>(data)->enable();
+                          return G_SOURCE_REMOVE;
+                      },
+                      this);
+        reenable_delay_ms_ = next_backoff(reenable_delay_ms_);
+    }
+    else {
+        LOG_INFO("Input capture disabled (%s); waiting for user action", reason.empty() ? "unknown" : reason.c_str());
+    }
 }
 
 void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint32_t activation_id,
@@ -304,6 +346,7 @@ void PortalInputCapture::cb_activated(XdpInputCaptureSession* session, std::uint
     }
     activation_id_ = activation_id;
     is_active_ = true;
+    reenable_delay_ms_ = 1000;
 }
 
 void PortalInputCapture::cb_deactivated(XdpInputCaptureSession* session,

--- a/src/lib/platform/PortalInputCapture.h
+++ b/src/lib/platform/PortalInputCapture.h
@@ -26,6 +26,7 @@
 #include <glib.h>
 #include <libportal/portal.h>
 #include <libportal/inputcapture.h>
+#include <string>
 
 namespace inputleap {
 
@@ -52,6 +53,9 @@ private:
     void cb_deactivated(XdpInputCaptureSession* session, std::uint32_t activation_id,
                         GVariant* options);
     void cb_zones_changed(XdpInputCaptureSession *session, GVariant *options);
+
+    static bool is_transient_disable(GVariant* options, std::string& reason);
+    static unsigned int next_backoff(unsigned int current_ms);
 
     /// g_signal_connect callback wrapper
     static void cb_session_closed_cb(XdpSession* session, gpointer data)
@@ -98,6 +102,7 @@ private:
     std::uint32_t activation_id_ = 0;
 
     std::vector<XdpInputCapturePointerBarrier*> barriers_;
+    unsigned int reenable_delay_ms_ = 1000;
 };
 
 } // namespace inputleap

--- a/src/test/unittests/CMakeLists.txt
+++ b/src/test/unittests/CMakeLists.txt
@@ -45,10 +45,12 @@ endif()
 if (BUILD_XWINDOWS)
     file(GLOB xwin_sources "platform/XWindows*.cpp")
     file(GLOB xwin_headers "platform/XWindows*.h")
+    file(GLOB portal_sources "platform/Portal*.cpp")
+    file(GLOB portal_headers "platform/Portal*.h")
 endif()
 
-list(APPEND sources ${mswin_sources} ${carbon_sources} ${xwin_sources})
-list(APPEND headers ${mswin_headers} ${carbon_headers} ${xwin_headers})
+list(APPEND sources ${mswin_sources} ${carbon_sources} ${xwin_sources} ${portal_sources})
+list(APPEND headers ${mswin_headers} ${carbon_headers} ${xwin_headers} ${portal_headers})
 
 include_directories(
     ../../

--- a/src/test/unittests/platform/PortalInputCaptureTests.cpp
+++ b/src/test/unittests/platform/PortalInputCaptureTests.cpp
@@ -1,0 +1,39 @@
+#include "config.h"
+#if HAVE_LIBPORTAL_INPUTCAPTURE
+#include "platform/PortalInputCapture.h"
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <string>
+
+namespace inputleap {
+
+TEST(PortalInputCaptureTests, NextBackoffIncreases)
+{
+    unsigned int delay = PortalInputCapture::next_backoff(1000);
+    EXPECT_EQ(2000u, delay);
+    delay = PortalInputCapture::next_backoff(30000);
+    EXPECT_EQ(60000u, delay);
+}
+
+TEST(PortalInputCaptureTests, TransientDisableParsing)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&builder, "{sv}", "reason", g_variant_new_string("timeout"));
+    GVariant* opts = g_variant_builder_end(&builder);
+    std::string reason;
+    EXPECT_TRUE(PortalInputCapture::is_transient_disable(opts, reason));
+    EXPECT_EQ("timeout", reason);
+    g_variant_unref(opts);
+
+    g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&builder, "{sv}", "reason", g_variant_new_string("user"));
+    opts = g_variant_builder_end(&builder);
+    reason.clear();
+    EXPECT_FALSE(PortalInputCapture::is_transient_disable(opts, reason));
+    EXPECT_EQ("user", reason);
+    g_variant_unref(opts);
+}
+
+} // namespace inputleap
+#endif // HAVE_LIBPORTAL_INPUTCAPTURE


### PR DESCRIPTION
## Summary
- track portal input capture disable reasons and log available options
- retry enabling only on transient errors with exponential backoff
- add unit tests for backoff and option parsing

## Testing
- `./clean_build.sh` (without GUI)
- `./build/bin/unittests` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68a8056b999c8325871502aefc00cb7f