### PR TITLE
Implement POSIX thread priority handling

### DIFF
--- a/src/lib/arch/IArchMultithread.h
+++ b/src/lib/arch/IArchMultithread.h
@@ -138,7 +138,8 @@ public:
     the thread has a lower priority and if negative a higher priority.
     Some architectures may not support either or both directions.
     */
-    virtual void setPriorityOfThread(ArchThread, int n) = 0;
+    // returns true on success, false if unsupported or on failure
+    virtual bool setPriorityOfThread(ArchThread, int n) = 0;
 
     //! Cancellation point
     /*!

--- a/src/lib/arch/unix/ArchMultithreadPosix.cpp
+++ b/src/lib/arch/unix/ArchMultithreadPosix.cpp
@@ -21,6 +21,7 @@
 #include "arch/Arch.h"
 #include "arch/XArch.h"
 #include "base/Time.h"
+#include "base/Log.h"
 
 #include <signal.h>
 #include <sys/time.h>
@@ -28,6 +29,8 @@
 #include <cerrno>
 #include <csignal>
 #include <fstream>
+#include <sched.h>
+#include <cstring>
 
 #define SIGWAKEUP SIGUSR1
 
@@ -292,12 +295,43 @@ ArchMultithreadPosix::cancelThread(ArchThread thread)
     }
 }
 
-void
-ArchMultithreadPosix::setPriorityOfThread(ArchThread thread, int /*n*/)
+bool
+ArchMultithreadPosix::setPriorityOfThread(ArchThread thread, int n)
 {
     assert(thread != nullptr);
 
-    // FIXME
+    int policy;
+    struct sched_param param;
+    int status = pthread_getschedparam(thread->m_thread, &policy, &param);
+    if (status != 0) {
+        LOG_DEBUG1("pthread_getschedparam failed: %s", std::strerror(status));
+        return false;
+    }
+
+    int min = sched_get_priority_min(policy);
+    int max = sched_get_priority_max(policy);
+    if (min == -1 || max == -1 || min == max) {
+        // policy doesn't support changing priorities
+        LOG_DEBUG1("thread policy %d does not support priorities", policy);
+        return false;
+    }
+
+    int newPriority = param.sched_priority - n;
+    if (newPriority < min) {
+        newPriority = min;
+    }
+    else if (newPriority > max) {
+        newPriority = max;
+    }
+
+    param.sched_priority = newPriority;
+    status = pthread_setschedparam(thread->m_thread, policy, &param);
+    if (status != 0) {
+        LOG_DEBUG1("pthread_setschedparam failed: %s", std::strerror(status));
+        return false;
+    }
+
+    return true;
 }
 
 void
@@ -536,7 +570,9 @@ void
 ArchMultithreadPosix::doThreadFunc(ArchThread thread)
 {
     // default priority is slightly below normal
-    setPriorityOfThread(thread, 1);
+    if (!setPriorityOfThread(thread, 1)) {
+        LOG_DEBUG1("failed to set default thread priority");
+    }
 
     // wait for parent to initialize this object
     {

--- a/src/lib/arch/unix/ArchMultithreadPosix.h
+++ b/src/lib/arch/unix/ArchMultithreadPosix.h
@@ -57,7 +57,7 @@ public:
     ArchThread copyThread(ArchThread) override;
     void closeThread(ArchThread) override;
     void cancelThread(ArchThread) override;
-    void setPriorityOfThread(ArchThread, int n) override;
+    bool setPriorityOfThread(ArchThread, int n) override;
     void testCancelThread() override;
     bool wait(ArchThread, double timeout) override;
     bool isSameThread(ArchThread, ArchThread) override;

--- a/src/lib/arch/win32/ArchMultithreadWindows.cpp
+++ b/src/lib/arch/win32/ArchMultithreadWindows.cpp
@@ -23,6 +23,7 @@
 #include "arch/win32/ArchMultithreadWindows.h"
 #include "arch/Arch.h"
 #include "arch/XArch.h"
+#include "base/Log.h"
 
 #include <process.h>
 
@@ -214,7 +215,7 @@ ArchMultithreadWindows::cancelThread(ArchThread thread)
     SetEvent(thread->m_cancel);
 }
 
-void
+bool
 ArchMultithreadWindows::setPriorityOfThread(ArchThread thread, int n)
 {
     struct PriorityInfo {
@@ -269,8 +270,13 @@ ArchMultithreadWindows::setPriorityOfThread(ArchThread thread, int n)
             index = s_pMax;
         }
     }
-    SetPriorityClass(GetCurrentProcess(), s_pClass[index].m_class);
-    SetThreadPriority(thread->m_thread, s_pClass[index].m_level);
+    BOOL ok1 = SetPriorityClass(GetCurrentProcess(), s_pClass[index].m_class);
+    BOOL ok2 = SetThreadPriority(thread->m_thread, s_pClass[index].m_level);
+    if (!ok1 || !ok2) {
+        LOG_DEBUG1("failed to set thread priority");
+        return false;
+    }
+    return true;
 }
 
 void

--- a/src/lib/arch/win32/ArchMultithreadWindows.h
+++ b/src/lib/arch/win32/ArchMultithreadWindows.h
@@ -59,7 +59,7 @@ public:
     virtual ArchThread copyThread(ArchThread);
     virtual void closeThread(ArchThread);
     virtual void cancelThread(ArchThread);
-    virtual void setPriorityOfThread(ArchThread, int n);
+    virtual bool setPriorityOfThread(ArchThread, int n) override;
     virtual void testCancelThread();
     virtual bool wait(ArchThread, double timeout);
     virtual bool isSameThread(ArchThread, ArchThread);

--- a/src/lib/inputleap/win32/AppUtilWindows.cpp
+++ b/src/lib/inputleap/win32/AppUtilWindows.cpp
@@ -145,7 +145,9 @@ AppUtilWindows::run(int argc, char** argv)
     ArchMiscWindows::setInstanceWin32(GetModuleHandle(nullptr));
 
     MSWindowsScreen::init(ArchMiscWindows::instanceWin32());
-    Thread::getCurrentThread().setPriority(-14);
+    if (!Thread::getCurrentThread().setPriority(-14)) {
+        LOG_DEBUG1("failed to set thread priority");
+    }
 
     StartupFunc startup;
     if (ArchMiscWindows::wasLaunchedAsService()) {

--- a/src/lib/mt/Thread.cpp
+++ b/src/lib/mt/Thread.cpp
@@ -74,10 +74,10 @@ Thread::cancel()
     ARCH->cancelThread(m_thread);
 }
 
-void
+bool
 Thread::setPriority(int n)
 {
-    ARCH->setPriorityOfThread(m_thread, n);
+    return ARCH->setPriorityOfThread(m_thread, n);
 }
 
 void

--- a/src/lib/mt/Thread.h
+++ b/src/lib/mt/Thread.h
@@ -123,7 +123,7 @@ public:
     the next lower, etc.  -1 is the next higher, etc. but boosting
     the priority may not be permitted and will be silently ignored.
     */
-    void setPriority(int n);
+    bool setPriority(int n);
 
     //! Force pollSocket() to return
     /*!


### PR DESCRIPTION
## Summary
- implement pthread-based thread priority logic in the POSIX backend with logging on failure
- return status from setPriorityOfThread and propagate through Thread API
- adjust callers to gracefully handle unsupported priority changes

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(interrupted at ~83%)*

------
https://chatgpt.com/codex/tasks/task_b_68a808d7c584832593257b7e8d84b43e