### PR TITLE
Reject unsupported portable mode flags

### DIFF
--- a/doc/input-leapc.1
+++ b/doc/input-leapc.1
@@ -53,6 +53,12 @@ display this help and exit.
 .TP
 \fB\-\-version\fR
 display version information and exit.
+.TP
+\fB\-\-server\fR
+reserved for a portable mode that is not implemented; using it will result in an error. Use \fBinput-leaps\fR instead.
+.TP
+\fB\-\-client\fR
+reserved for a portable mode that is not implemented; using it will result in an error. Use \fBinput-leapc\fR instead.
 .PP
 Default options are marked with a *
 .PP

--- a/doc/input-leaps.1
+++ b/doc/input-leaps.1
@@ -59,6 +59,12 @@ display this help and exit.
 .TP
 \fB\-\-version\fR
 display version information and exit.
+.TP
+\fB\-\-server\fR
+reserved for a portable mode that is not implemented; using it will result in an error. This binary already runs as the server.
+.TP
+\fB\-\-client\fR
+reserved for a portable mode that is not implemented; using it will result in an error. Use \fBinput-leapc\fR for client functionality.
 .PP
 Default options are marked with a *
 .PP

--- a/doc/newsfragments/portable-cli-error.bugfix
+++ b/doc/newsfragments/portable-cli-error.bugfix
@@ -1,0 +1,1 @@
+Add explicit error messages for the `--server` and `--client` flags when portable mode is requested.

--- a/src/lib/inputleap/ArgParser.cpp
+++ b/src/lib/inputleap/ArgParser.cpp
@@ -449,12 +449,12 @@ ArgParser::parseGenericArgs(Argv& argv)
         argsBase().m_enableIpc = true;
     }
     else if (argv.shift("--server")) {
-        // HACK: stop error happening when using portable app.
-        // FIXME: there is no portable InputLeap
+        throw XArgvParserError(
+            "portable mode (--server) is not supported; use input-leaps for server functionality");
     }
     else if (argv.shift("--client")) {
-        // HACK: stop error happening when using portable app.
-        // FIXME: there is no portable InputLeap.
+        throw XArgvParserError(
+            "portable mode (--client) is not supported; use input-leapc for client functionality");
     }
     else if (argv.shift("--enable-drag-drop")) {
         bool useDragDrop = true;


### PR DESCRIPTION
## Summary
- throw a clear error when `--server` or `--client` is supplied, since portable mode isn't implemented
- document that `--server` and `--client` flags are unsupported and will error

## Testing
- `./clean_build.sh` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_b_68a80a87732483259abe3381e2ec9c61