### PR TITLE
Fix hotkey id rollover in EiScreen

### DIFF
--- a/src/lib/platform/EiScreen.cpp
+++ b/src/lib/platform/EiScreen.cpp
@@ -200,9 +200,10 @@ void EiScreen::warpCursor(int32_t x, int32_t y)
 std::uint32_t EiScreen::registerHotKey(KeyID key, KeyModifierMask mask)
 {
     static std::uint32_t next_id;
-    std::uint32_t id = std::min(++next_id, 1u);
-
-    // Bug: id rollover means duplicate hotkey ids. Oh well.
+    if (++next_id == 0) {
+        next_id = 1;
+    }
+    std::uint32_t id = next_id;
 
     auto set = hotkeys_.find(key);
     if (set == hotkeys_.end()) {


### PR DESCRIPTION
## Summary
- ensure hotkey IDs wrap to 1 when overflow occurs

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: interrupted after ~58%)*

------
https://chatgpt.com/codex/tasks/task_b_68a8dde6886c8325bbc98f098b878e0f