### PR TITLE
Prevent duplicate fingerprints when re-reading database

### DIFF
--- a/src/lib/net/FingerprintDatabase.cpp
+++ b/src/lib/net/FingerprintDatabase.cpp
@@ -54,7 +54,9 @@ void FingerprintDatabase::read_stream(std::istream& stream)
             continue;
         }
 
-        fingerprints_.push_back(fingerprint);
+        // Avoid inserting duplicate fingerprints if read_stream is called
+        // multiple times with the same data.
+        add_trusted(fingerprint);
     }
 }
 

--- a/src/test/unittests/net/FingerprintDatabaseTests.cpp
+++ b/src/test/unittests/net/FingerprintDatabaseTests.cpp
@@ -92,4 +92,17 @@ TEST(FingerprintDatabase, is_trusted)
     ASSERT_FALSE(db.is_trusted({ "algo1", { 1, 2, 3, 4, 0xac } }));
 }
 
+TEST(FingerprintDatabase, repeated_reads_do_not_duplicate)
+{
+    std::istringstream stream1("v2:algo1:01020304ab\n");
+    FingerprintDatabase db;
+    db.read_stream(stream1);
+
+    // Read the same fingerprint again to ensure it isn't added twice.
+    std::istringstream stream2("v2:algo1:01020304ab\n");
+    db.read_stream(stream2);
+
+    ASSERT_EQ(db.fingerprints().size(), 1u);
+}
+
 } // namespace inputleap


### PR DESCRIPTION
## Summary
- avoid adding duplicate fingerprints when loading from a stream multiple times
- add regression test for repeated reads

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF -DINPUTLEAP_BUILD_X11=ON -DINPUTLEAP_BUILD_LIBEI=OFF -DINPUTLEAP_USE_EXTERNAL_GTEST=ON -DINPUTLEAP_BUILD_TESTS=ON`
- `cmake --build build --target unittests`
- `./build/bin/unittests` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68a8e31d4a008325bd147813af085d09