### PR TITLE
Fix hotkey removal selection handling

### DIFF
--- a/src/gui/src/ServerConfigDialog.cpp
+++ b/src/gui/src/ServerConfigDialog.cpp
@@ -137,7 +137,18 @@ void ServerConfigDialog::on_m_pButtonRemoveHotkey_clicked()
     Q_ASSERT(idx >= 0 && idx < static_cast<int>(serverConfig().hotkeys().size()));
     serverConfig().hotkeys().erase(serverConfig().hotkeys().begin() + idx);
     ui_->m_pListActions->clear();
-    delete ui_->m_pListHotkeys->item(idx);
+    ui_->m_pListHotkeys->blockSignals(true);
+    delete ui_->m_pListHotkeys->takeItem(idx);
+
+    int count = ui_->m_pListHotkeys->count();
+    if (count > 0)
+    {
+        if (idx >= count)
+            idx = count - 1;
+        ui_->m_pListHotkeys->setCurrentRow(idx);
+    }
+    ui_->m_pListHotkeys->blockSignals(false);
+    on_m_pListHotkeys_itemSelectionChanged();
 }
 
 void ServerConfigDialog::on_m_pListHotkeys_itemSelectionChanged()
@@ -152,14 +163,6 @@ void ServerConfigDialog::on_m_pListHotkeys_itemSelectionChanged()
         ui_->m_pListActions->clear();
 
         int idx = ui_->m_pListHotkeys->row(ui_->m_pListHotkeys->selectedItems()[0]);
-
-        // There's a bug somewhere around here: We get idx == 1 right after we deleted the next to last item, so idx can
-        // only possibly be 0. GDB shows we got called indirectly from the delete line in
-        // on_m_pButtonRemoveHotkey_clicked() above, but the delete is of course necessary and seems correct.
-        // The while() is a generalized workaround for all that and shouldn't be required.
-        while (idx >= 0 && idx >= static_cast<int>(serverConfig().hotkeys().size()))
-            idx--;
-
         Q_ASSERT(idx >= 0 && idx < static_cast<int>(serverConfig().hotkeys().size()));
 
         const Hotkey& hotkey = serverConfig().hotkeys()[idx];


### PR DESCRIPTION
## Summary
- Update hotkey removal to adjust selection before triggering updates and handle last-item deletion
- Simplify hotkey selection change handler by removing fallback index decrement loop

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*


------
https://chatgpt.com/codex/tasks/task_b_68a8f9b0d0a48325987d83d0b070f3de