### PR TITLE
Throw when Windows registry key or name is null

### DIFF
--- a/src/lib/arch/win32/ArchMiscWindows.cpp
+++ b/src/lib/arch/win32/ArchMiscWindows.cpp
@@ -20,6 +20,7 @@
 #include "arch/win32/ArchDaemonWindows.h"
 #include "base/Log.h"
 #include "common/Version.h"
+#include <stdexcept>
 
 #include <Wtsapi32.h>
 #pragma warning(disable: 4099)
@@ -177,10 +178,11 @@ ArchMiscWindows::closeKey(HKEY key)
 void
 ArchMiscWindows::deleteKey(HKEY key, const TCHAR* name)
 {
-    assert(key != nullptr);
-    assert(name != nullptr);
-    if (key == nullptr || name == nullptr) {
-        return;
+    if (key == nullptr) {
+        throw std::invalid_argument("Registry key is null");
+    }
+    if (name == nullptr) {
+        throw std::invalid_argument("Registry key name is null");
     }
     RegDeleteKey(key, name);
 }
@@ -188,9 +190,12 @@ ArchMiscWindows::deleteKey(HKEY key, const TCHAR* name)
 void
 ArchMiscWindows::deleteValue(HKEY key, const TCHAR* name)
 {
-    assert(key != nullptr);
-    assert(name != nullptr);
-    if (key==nullptr || name==nullptr) return;
+    if (key == nullptr) {
+        throw std::invalid_argument("Registry key is null");
+    }
+    if (name == nullptr) {
+        throw std::invalid_argument("Registry value name is null");
+    }
     RegDeleteValue(key, name);
 }
 
@@ -230,10 +235,11 @@ void
 ArchMiscWindows::setValue(HKEY key,
                 const TCHAR* name, const std::string& value)
 {
-    assert(key != nullptr);
     if (key == nullptr) {
-        // TODO: throw exception
-        return;
+        throw std::invalid_argument("Registry key is null");
+    }
+    if (name == nullptr) {
+        throw std::invalid_argument("Registry value name is null");
     }
     RegSetValueEx(key, name, 0, REG_SZ,
                                 reinterpret_cast<const BYTE*>(value.c_str()),
@@ -243,10 +249,11 @@ ArchMiscWindows::setValue(HKEY key,
 void
 ArchMiscWindows::setValue(HKEY key, const TCHAR* name, DWORD value)
 {
-    assert(key != nullptr);
     if (key == nullptr) {
-        // TODO: throw exception
-        return;
+        throw std::invalid_argument("Registry key is null");
+    }
+    if (name == nullptr) {
+        throw std::invalid_argument("Registry value name is null");
     }
     RegSetValueEx(key, name, 0, REG_DWORD,
                                 reinterpret_cast<CONST BYTE*>(&value),
@@ -257,11 +264,11 @@ void
 ArchMiscWindows::setValueBinary(HKEY key,
                 const TCHAR* name, const std::string& value)
 {
-    assert(key != nullptr);
-    assert(name != nullptr);
-    if (key == nullptr || name == nullptr) {
-        // TODO: throw exception
-        return;
+    if (key == nullptr) {
+        throw std::invalid_argument("Registry key is null");
+    }
+    if (name == nullptr) {
+        throw std::invalid_argument("Registry value name is null");
     }
     RegSetValueEx(key, name, 0, REG_BINARY,
                                 reinterpret_cast<const BYTE*>(value.data()),

--- a/src/test/unittests/platform/MSWindowsArchMiscWindowsTests.cpp
+++ b/src/test/unittests/platform/MSWindowsArchMiscWindowsTests.cpp
@@ -1,0 +1,50 @@
+#include "arch/win32/ArchMiscWindows.h"
+#include <gtest/gtest.h>
+
+using namespace inputleap;
+
+TEST(MSWindowsArchMiscWindows, deleteKeyThrowsOnNullKey) {
+    EXPECT_THROW(ArchMiscWindows::deleteKey(nullptr, _T("foo")), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, deleteKeyThrowsOnNullName) {
+    HKEY dummy = reinterpret_cast<HKEY>(1);
+    EXPECT_THROW(ArchMiscWindows::deleteKey(dummy, nullptr), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, deleteValueThrowsOnNullKey) {
+    EXPECT_THROW(ArchMiscWindows::deleteValue(nullptr, _T("foo")), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, deleteValueThrowsOnNullName) {
+    HKEY dummy = reinterpret_cast<HKEY>(1);
+    EXPECT_THROW(ArchMiscWindows::deleteValue(dummy, nullptr), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueThrowsOnNullKey) {
+    EXPECT_THROW(ArchMiscWindows::setValue(nullptr, _T("foo"), std::string("bar")), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueThrowsOnNullName) {
+    HKEY dummy = reinterpret_cast<HKEY>(1);
+    EXPECT_THROW(ArchMiscWindows::setValue(dummy, nullptr, std::string("bar")), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueDwordThrowsOnNullKey) {
+    EXPECT_THROW(ArchMiscWindows::setValue(nullptr, _T("foo"), static_cast<DWORD>(5)), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueDwordThrowsOnNullName) {
+    HKEY dummy = reinterpret_cast<HKEY>(1);
+    EXPECT_THROW(ArchMiscWindows::setValue(dummy, nullptr, static_cast<DWORD>(5)), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueBinaryThrowsOnNullKey) {
+    EXPECT_THROW(ArchMiscWindows::setValueBinary(nullptr, _T("foo"), std::string("bar")), std::invalid_argument);
+}
+
+TEST(MSWindowsArchMiscWindows, setValueBinaryThrowsOnNullName) {
+    HKEY dummy = reinterpret_cast<HKEY>(1);
+    EXPECT_THROW(ArchMiscWindows::setValueBinary(dummy, nullptr, std::string("bar")), std::invalid_argument);
+}
+


### PR DESCRIPTION
## Summary
- throw `std::invalid_argument` if Windows registry functions receive null `key` or `name`
- cover invalid registry arguments with new unit tests

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF` *(fails: The following required packages were not found: xrandr, xinerama, xtst, xi)*

------
https://chatgpt.com/codex/tasks/task_b_68a967bdee3883259a46bd28acdeca3f