### PR TITLE
Refactor proxy parsing error handling

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -18,40 +18,40 @@
 
 #include "client/ServerProxy.h"
 
+#include "base/EventQueueTimer.h"
+#include "base/IEventQueue.h"
+#include "base/Log.h"
+#include "base/XBase.h"
 #include "client/Client.h"
-#include "inputleap/FileChunk.h"
-#include "inputleap/ClipboardChunk.h"
-#include "inputleap/StreamChunker.h"
 #include "inputleap/Clipboard.h"
+#include "inputleap/ClipboardChunk.h"
+#include "inputleap/Exceptions.h"
+#include "inputleap/FileChunk.h"
 #include "inputleap/ProtocolUtil.h"
+#include "inputleap/StreamChunker.h"
 #include "inputleap/option_types.h"
 #include "inputleap/protocol_types.h"
-#include "inputleap/Exceptions.h"
 #include "io/IStream.h"
-#include "base/Log.h"
-#include "base/IEventQueue.h"
-#include "base/EventQueueTimer.h"
-#include "base/XBase.h"
 
 #include <memory>
 
 namespace inputleap {
 
-ServerProxy::ServerProxy(Client* client, inputleap::IStream* stream, IEventQueue* events) :
-    m_client(client),
-    m_stream(stream),
-    m_seqNum(0),
-    m_compressMouse(false),
-    m_compressMouseRelative(false),
-    m_xMouse(0),
-    m_yMouse(0),
-    m_dxMouse(0),
-    m_dyMouse(0),
-    m_ignoreMouse(false),
-    m_keepAliveAlarm(0.0),
-    m_keepAliveAlarmTimer(nullptr),
-    m_parser(&ServerProxy::parseHandshakeMessage),
-    m_events(events)
+ServerProxy::ServerProxy(Client* client, inputleap::IStream* stream, IEventQueue* events)
+  : m_client(client)
+  , m_stream(stream)
+  , m_seqNum(0)
+  , m_compressMouse(false)
+  , m_compressMouseRelative(false)
+  , m_xMouse(0)
+  , m_yMouse(0)
+  , m_dxMouse(0)
+  , m_dyMouse(0)
+  , m_ignoreMouse(false)
+  , m_keepAliveAlarm(0.0)
+  , m_keepAliveAlarmTimer(nullptr)
+  , m_parser(&ServerProxy::parseHandshakeMessage)
+  , m_events(events)
 {
     assert(m_client != nullptr);
     assert(m_stream != nullptr);
@@ -61,10 +61,12 @@ ServerProxy::ServerProxy(Client* client, inputleap::IStream* stream, IEventQueue
         m_modifierTranslationTable[id] = id;
 
     // handle data on stream
-    m_events->add_handler(EventType::STREAM_INPUT_READY, m_stream->get_event_target(),
-                          [this](const auto& e){ handle_data(); });
-    m_events->add_handler(EventType::CLIPBOARD_SENDING, this,
-                          [this](const auto& e){ handle_clipboard_sending_event(e); });
+    m_events->add_handler(EventType::STREAM_INPUT_READY,
+                          m_stream->get_event_target(),
+                          [this](const auto& e) { handle_data(); });
+    m_events->add_handler(EventType::CLIPBOARD_SENDING, this, [this](const auto& e) {
+        handle_clipboard_sending_event(e);
+    });
 
     // send heartbeat
     setKeepAliveRate(kKeepAliveRate);
@@ -86,10 +88,10 @@ ServerProxy::resetKeepAliveAlarm()
         m_keepAliveAlarmTimer = nullptr;
     }
     if (m_keepAliveAlarm > 0.0) {
-        m_keepAliveAlarmTimer =
-            m_events->newOneShotTimer(m_keepAliveAlarm, nullptr);
-        m_events->add_handler(EventType::TIMER, m_keepAliveAlarmTimer,
-                              [this](const auto& e){ handle_keep_alive_alarm(); });
+        m_keepAliveAlarmTimer = m_events->newOneShotTimer(m_keepAliveAlarm, nullptr);
+        m_events->add_handler(EventType::TIMER, m_keepAliveAlarmTimer, [this](const auto& e) {
+            handle_keep_alive_alarm();
+        });
     }
 }
 
@@ -100,7 +102,8 @@ ServerProxy::setKeepAliveRate(double rate)
     resetKeepAliveAlarm();
 }
 
-void ServerProxy::handle_data()
+void
+ServerProxy::handle_data()
 {
     // handle messages until there are no more.  first read message code.
     std::uint8_t code[4];
@@ -109,7 +112,7 @@ void ServerProxy::handle_data()
         // verify we got an entire code
         if (n != 4) {
             LOG_ERR("incomplete message from server: %d bytes", n);
-            m_client->disconnect("incomplete message from server");
+            disconnect("incomplete message from server");
             return;
         }
 
@@ -117,18 +120,20 @@ void ServerProxy::handle_data()
         LOG_DEBUG2("msg from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
         try {
             switch ((this->*m_parser)(code)) {
-            case kOkay:
-                break;
+                case kOkay:
+                    break;
 
-            case kUnknown:
-                LOG_ERR("invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
-                m_client->disconnect("invalid message from server");
-                return;
+                case kUnknown:
+                    LOG_ERR(
+                      "invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
+                    disconnect("invalid message from server");
+                    return;
 
-            case kDisconnect:
-                return;
-            default:
-                break;
+                case kDisconnect:
+                    disconnect(m_disconnectReason.empty() ? nullptr : m_disconnectReason.c_str());
+                    return;
+                default:
+                    break;
             }
         } catch (const XBadClient& e) {
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
@@ -136,7 +141,7 @@ void ServerProxy::handle_data()
 
             LOG_ERR("protocol error from server: %s", e.what());
             ProtocolUtil::writef(m_stream, kMsgEBad);
-            m_client->disconnect("invalid message from server");
+            disconnect("invalid message from server");
             return;
         }
 
@@ -147,7 +152,8 @@ void ServerProxy::handle_data()
     flushCompressedMouse();
 }
 
-ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code)
+ServerProxy::EResult
+ServerProxy::parseHandshakeMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgQInfo, 4) == 0) {
         queryInfo();
@@ -182,44 +188,44 @@ ServerProxy::EResult ServerProxy::parseHandshakeMessage(const std::uint8_t* code
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
         LOG_DEBUG1("recv close");
-        m_client->disconnect(nullptr);
+        m_disconnectReason.clear();
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEIncompatible, 4) == 0) {
         std::int32_t major, minor;
-        ProtocolUtil::readf(m_stream,
-                        kMsgEIncompatible + 4, &major, &minor);
+        ProtocolUtil::readf(m_stream, kMsgEIncompatible + 4, &major, &minor);
         LOG_ERR("server has incompatible version %d.%d", major, minor);
-        m_client->disconnect("server has incompatible version");
+        m_disconnectReason = "server has incompatible version";
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBusy, 4) == 0) {
-        LOG_ERR("server already has a connected client with name \"%s\"", m_client->getName().c_str());
-        m_client->disconnect("server already has a connected client with our name");
+        LOG_ERR("server already has a connected client with name \"%s\"",
+                m_client->getName().c_str());
+        m_disconnectReason = "server already has a connected client with our name";
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEUnknown, 4) == 0) {
         LOG_ERR("server refused client with name \"%s\"", m_client->getName().c_str());
-        m_client->disconnect("server refused client with our name");
+        m_disconnectReason = "server refused client with our name";
         return kDisconnect;
     }
 
     else if (memcmp(code, kMsgEBad, 4) == 0) {
         LOG_ERR("server disconnected due to a protocol error");
-        m_client->disconnect("server reported a protocol error");
+        m_disconnectReason = "server reported a protocol error";
         return kDisconnect;
-    }
-    else {
+    } else {
         return kUnknown;
     }
 
     return kOkay;
 }
 
-ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
+ServerProxy::EResult
+ServerProxy::parseMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgDMouseMove, 4) == 0) {
         mouseMove();
@@ -301,23 +307,20 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
 
     else if (memcmp(code, kMsgDFileTransfer, 4) == 0) {
         fileChunkReceived();
-    }
-    else if (memcmp(code, kMsgDDragInfo, 4) == 0) {
+    } else if (memcmp(code, kMsgDDragInfo, 4) == 0) {
         dragInfoReceived();
     }
 
     else if (memcmp(code, kMsgCClose, 4) == 0) {
         // server wants us to hangup
         LOG_DEBUG1("recv close");
-        m_client->disconnect(nullptr);
+        m_disconnectReason.clear();
         return kDisconnect;
-    }
-    else if (memcmp(code, kMsgEBad, 4) == 0) {
+    } else if (memcmp(code, kMsgEBad, 4) == 0) {
         LOG_ERR("server disconnected due to a protocol error");
-        m_client->disconnect("server reported a protocol error");
+        m_disconnectReason = "server reported a protocol error";
         return kDisconnect;
-    }
-    else {
+    } else {
         return kUnknown;
     }
 
@@ -333,10 +336,11 @@ ServerProxy::EResult ServerProxy::parseMessage(const std::uint8_t* code)
     return kOkay;
 }
 
-void ServerProxy::handle_keep_alive_alarm()
+void
+ServerProxy::handle_keep_alive_alarm()
 {
     LOG_NOTE("server is dead");
-    m_client->disconnect("server is not responding");
+    disconnect("server is not responding");
 }
 
 void
@@ -386,90 +390,83 @@ void
 ServerProxy::sendInfo(const ClientInfo& info)
 {
     LOG_DEBUG1("sending info shape=%d,%d %dx%d", info.m_x, info.m_y, info.m_w, info.m_h);
-    ProtocolUtil::writef(m_stream, kMsgDInfo,
-                                info.m_x, info.m_y,
-                                info.m_w, info.m_h, 0,
-                                info.m_mx, info.m_my);
+    ProtocolUtil::writef(
+      m_stream, kMsgDInfo, info.m_x, info.m_y, info.m_w, info.m_h, 0, info.m_mx, info.m_my);
 }
 
 KeyID
 ServerProxy::translateKey(KeyID id) const
 {
     static const KeyID s_translationTable[kKeyModifierIDLast][2] = {
-        { kKeyNone,      kKeyNone },
-        { kKeyShift_L,   kKeyShift_R },
-        { kKeyControl_L, kKeyControl_R },
-        { kKeyAlt_L,     kKeyAlt_R },
-        { kKeyMeta_L,    kKeyMeta_R },
-        { kKeySuper_L,   kKeySuper_R },
-        { kKeyAltGr,     kKeyAltGr}
+        { kKeyNone, kKeyNone },   { kKeyShift_L, kKeyShift_R }, { kKeyControl_L, kKeyControl_R },
+        { kKeyAlt_L, kKeyAlt_R }, { kKeyMeta_L, kKeyMeta_R },   { kKeySuper_L, kKeySuper_R },
+        { kKeyAltGr, kKeyAltGr }
     };
 
     KeyModifierID id2 = kKeyModifierIDNull;
     std::uint32_t side = 0;
     switch (id) {
-    case kKeyShift_L:
-        id2  = kKeyModifierIDShift;
-        side = 0;
-        break;
+        case kKeyShift_L:
+            id2 = kKeyModifierIDShift;
+            side = 0;
+            break;
 
-    case kKeyShift_R:
-        id2  = kKeyModifierIDShift;
-        side = 1;
-        break;
+        case kKeyShift_R:
+            id2 = kKeyModifierIDShift;
+            side = 1;
+            break;
 
-    case kKeyControl_L:
-        id2  = kKeyModifierIDControl;
-        side = 0;
-        break;
+        case kKeyControl_L:
+            id2 = kKeyModifierIDControl;
+            side = 0;
+            break;
 
-    case kKeyControl_R:
-        id2  = kKeyModifierIDControl;
-        side = 1;
-        break;
+        case kKeyControl_R:
+            id2 = kKeyModifierIDControl;
+            side = 1;
+            break;
 
-    case kKeyAlt_L:
-        id2  = kKeyModifierIDAlt;
-        side = 0;
-        break;
+        case kKeyAlt_L:
+            id2 = kKeyModifierIDAlt;
+            side = 0;
+            break;
 
-    case kKeyAlt_R:
-        id2  = kKeyModifierIDAlt;
-        side = 1;
-        break;
+        case kKeyAlt_R:
+            id2 = kKeyModifierIDAlt;
+            side = 1;
+            break;
 
-    case kKeyAltGr:
-        id2 = kKeyModifierIDAltGr;
-        side = 1; // there is only one alt gr key on the right side
-        break;
+        case kKeyAltGr:
+            id2 = kKeyModifierIDAltGr;
+            side = 1; // there is only one alt gr key on the right side
+            break;
 
-    case kKeyMeta_L:
-        id2  = kKeyModifierIDMeta;
-        side = 0;
-        break;
+        case kKeyMeta_L:
+            id2 = kKeyModifierIDMeta;
+            side = 0;
+            break;
 
-    case kKeyMeta_R:
-        id2  = kKeyModifierIDMeta;
-        side = 1;
-        break;
+        case kKeyMeta_R:
+            id2 = kKeyModifierIDMeta;
+            side = 1;
+            break;
 
-    case kKeySuper_L:
-        id2  = kKeyModifierIDSuper;
-        side = 0;
-        break;
+        case kKeySuper_L:
+            id2 = kKeyModifierIDSuper;
+            side = 0;
+            break;
 
-    case kKeySuper_R:
-        id2  = kKeyModifierIDSuper;
-        side = 1;
-        break;
-    default:
-        break;
+        case kKeySuper_R:
+            id2 = kKeyModifierIDSuper;
+            side = 1;
+            break;
+        default:
+            break;
     }
 
     if (id2 != kKeyModifierIDNull) {
         return s_translationTable[m_modifierTranslationTable[id2]][side];
-    }
-    else {
+    } else {
         return id;
     }
 }
@@ -478,21 +475,12 @@ KeyModifierMask
 ServerProxy::translateModifierMask(KeyModifierMask mask) const
 {
     static const KeyModifierMask s_masks[kKeyModifierIDLast] = {
-        0x0000,
-        KeyModifierShift,
-        KeyModifierControl,
-        KeyModifierAlt,
-        KeyModifierMeta,
-        KeyModifierSuper,
-        KeyModifierAltGr
+        0x0000,          KeyModifierShift, KeyModifierControl, KeyModifierAlt,
+        KeyModifierMeta, KeyModifierSuper, KeyModifierAltGr
     };
 
-    KeyModifierMask newMask = mask & ~(KeyModifierShift |
-                                        KeyModifierControl |
-                                        KeyModifierAlt |
-                                        KeyModifierMeta |
-                                        KeyModifierSuper |
-                                        KeyModifierAltGr );
+    KeyModifierMask newMask = mask & ~(KeyModifierShift | KeyModifierControl | KeyModifierAlt |
+                                       KeyModifierMeta | KeyModifierSuper | KeyModifierAltGr);
     if ((mask & KeyModifierShift) != 0) {
         newMask |= s_masks[m_modifierTranslationTable[kKeyModifierIDShift]];
     }
@@ -525,11 +513,11 @@ ServerProxy::enter()
     LOG_DEBUG1("recv enter, %d,%d %d %04x", x, y, seqNum, mask);
 
     // discard old compressed mouse motion, if any
-    m_compressMouse         = false;
+    m_compressMouse = false;
     m_compressMouseRelative = false;
-    m_dxMouse               = 0;
-    m_dyMouse               = 0;
-    m_seqNum                = seqNum;
+    m_dxMouse = 0;
+    m_dyMouse = 0;
+    m_seqNum = seqNum;
 
     // forward
     m_client->enter(x, y, seqNum, static_cast<KeyModifierMask>(mask), false);
@@ -561,8 +549,7 @@ ServerProxy::setClipboard()
     if (r == kStart) {
         size_t size = ClipboardChunk::getExpectedSize();
         LOG_DEBUG("receiving clipboard %d size=%zd", id, size);
-    }
-    else if (r == kFinish) {
+    } else if (r == kFinish) {
         LOG_DEBUG("received clipboard %d size=%zd", id, dataCached.size());
 
         // forward
@@ -604,11 +591,9 @@ ServerProxy::keyDown()
     LOG_DEBUG1("recv key down id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
-    KeyID id2             = translateKey(static_cast<KeyID>(id));
-    KeyModifierMask mask2 = translateModifierMask(
-                                static_cast<KeyModifierMask>(mask));
-    if (id2   != static_cast<KeyID>(id) ||
-        mask2 != static_cast<KeyModifierMask>(mask))
+    KeyID id2 = translateKey(static_cast<KeyID>(id));
+    KeyModifierMask mask2 = translateModifierMask(static_cast<KeyModifierMask>(mask));
+    if (id2 != static_cast<KeyID>(id) || mask2 != static_cast<KeyModifierMask>(mask))
         LOG_DEBUG1("key down translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
@@ -623,16 +608,14 @@ ServerProxy::keyRepeat()
 
     // parse
     std::uint16_t id, mask, count, button;
-    ProtocolUtil::readf(m_stream, kMsgDKeyRepeat + 4,
-                                &id, &mask, &count, &button);
-    LOG_DEBUG1("recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button);
+    ProtocolUtil::readf(m_stream, kMsgDKeyRepeat + 4, &id, &mask, &count, &button);
+    LOG_DEBUG1(
+      "recv key repeat id=0x%08x, mask=0x%04x, count=%d, button=0x%04x", id, mask, count, button);
 
     // translate
-    KeyID id2             = translateKey(static_cast<KeyID>(id));
-    KeyModifierMask mask2 = translateModifierMask(
-                                static_cast<KeyModifierMask>(mask));
-    if (id2   != static_cast<KeyID>(id) ||
-        mask2 != static_cast<KeyModifierMask>(mask))
+    KeyID id2 = translateKey(static_cast<KeyID>(id));
+    KeyModifierMask mask2 = translateModifierMask(static_cast<KeyModifierMask>(mask));
+    if (id2 != static_cast<KeyID>(id) || mask2 != static_cast<KeyModifierMask>(mask))
         LOG_DEBUG1("key repeat translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
@@ -651,11 +634,9 @@ ServerProxy::keyUp()
     LOG_DEBUG1("recv key up id=0x%08x, mask=0x%04x, button=0x%04x", id, mask, button);
 
     // translate
-    KeyID id2             = translateKey(static_cast<KeyID>(id));
-    KeyModifierMask mask2 = translateModifierMask(
-                                static_cast<KeyModifierMask>(mask));
-    if (id2   != static_cast<KeyID>(id) ||
-        mask2 != static_cast<KeyModifierMask>(mask))
+    KeyID id2 = translateKey(static_cast<KeyID>(id));
+    KeyModifierMask mask2 = translateModifierMask(static_cast<KeyModifierMask>(mask));
+    if (id2 != static_cast<KeyID>(id) || mask2 != static_cast<KeyModifierMask>(mask))
         LOG_DEBUG1("key up translated to id=0x%08x, mask=0x%04x", id2, mask2);
 
     // forward
@@ -711,9 +692,9 @@ ServerProxy::mouseMove()
     // if compressing then ignore the motion but record it
     if (m_compressMouse) {
         m_compressMouseRelative = false;
-        ignore    = true;
-        m_xMouse  = x;
-        m_yMouse  = y;
+        ignore = true;
+        m_xMouse = x;
+        m_yMouse = y;
         m_dxMouse = 0;
         m_dyMouse = 0;
     }
@@ -743,7 +724,7 @@ ServerProxy::mouseRelativeMove()
 
     // if compressing then ignore the motion but record it
     if (m_compressMouseRelative) {
-        ignore     = true;
+        ignore = true;
         m_dxMouse += dx;
         m_dyMouse += dy;
     }
@@ -816,30 +797,23 @@ ServerProxy::setOptions()
         KeyModifierID id = kKeyModifierIDNull;
         if (options[i] == kOptionModifierMapForShift) {
             id = kKeyModifierIDShift;
-        }
-        else if (options[i] == kOptionModifierMapForControl) {
+        } else if (options[i] == kOptionModifierMapForControl) {
             id = kKeyModifierIDControl;
-        }
-        else if (options[i] == kOptionModifierMapForAlt) {
+        } else if (options[i] == kOptionModifierMapForAlt) {
             id = kKeyModifierIDAlt;
-        }
-        else if (options[i] == kOptionModifierMapForAltGr) {
+        } else if (options[i] == kOptionModifierMapForAltGr) {
             id = kKeyModifierIDAltGr;
-        }
-        else if (options[i] == kOptionModifierMapForMeta) {
+        } else if (options[i] == kOptionModifierMapForMeta) {
             id = kKeyModifierIDMeta;
-        }
-        else if (options[i] == kOptionModifierMapForSuper) {
+        } else if (options[i] == kOptionModifierMapForSuper) {
             id = kKeyModifierIDSuper;
-        }
-        else if (options[i] == kOptionHeartbeat) {
+        } else if (options[i] == kOptionHeartbeat) {
             // update keep alive
             setKeepAliveRate(1.0e-3 * static_cast<double>(options[i + 1]));
         }
 
         if (id != kKeyModifierIDNull) {
-            m_modifierTranslationTable[id] =
-                static_cast<KeyModifierID>(options[i + 1]);
+            m_modifierTranslationTable[id] = static_cast<KeyModifierID>(options[i + 1]);
             LOG_DEBUG1("modifier %d mapped to %d", id, m_modifierTranslationTable[id]);
         }
     }
@@ -865,14 +839,11 @@ void
 ServerProxy::fileChunkReceived()
 {
     int result = FileChunk::assemble(
-                    m_stream,
-                    m_client->getReceivedFileData(),
-                    m_client->getExpectedFileSize());
+      m_stream, m_client->getReceivedFileData(), m_client->getExpectedFileSize());
 
     if (result == kFinish) {
         m_events->add_event(EventType::FILE_RECEIVE_COMPLETED, m_client);
-    }
-    else if (result == kStart) {
+    } else if (result == kStart) {
         if (m_client->getDragFileList().size() > 0) {
             std::string filename = m_client->getDragFileList().at(0).getFilename();
             LOG_DEBUG("start receiving %s", filename.c_str());
@@ -891,22 +862,31 @@ ServerProxy::dragInfoReceived()
     m_client->dragInfoReceived(fileNum, content);
 }
 
-void ServerProxy::handle_clipboard_sending_event(const Event& event)
+void
+ServerProxy::handle_clipboard_sending_event(const Event& event)
 {
     const auto& chunk = event.get_data_as<ClipboardChunk>();
-    ProtocolUtil::writef(m_stream, kMsgDClipboard, chunk.id_, chunk.sequence_, chunk.mark_,
-                         &chunk.data_);
+    ProtocolUtil::writef(
+      m_stream, kMsgDClipboard, chunk.id_, chunk.sequence_, chunk.mark_, &chunk.data_);
 }
 
-void ServerProxy::file_chunk_sending(const FileChunk& chunk)
+void
+ServerProxy::file_chunk_sending(const FileChunk& chunk)
 {
     ProtocolUtil::writef(m_stream, kMsgDFileTransfer, chunk.mark_, &chunk.data_);
 }
 
-void ServerProxy::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)
+void
+ServerProxy::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)
 {
     std::string data(info, size);
     ProtocolUtil::writef(m_stream, kMsgDDragInfo, fileCount, &data);
+}
+
+void
+ServerProxy::disconnect(const char* reason)
+{
+    m_client->disconnect(reason);
 }
 
 } // namespace inputleap

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -18,12 +18,13 @@
 
 #pragma once
 
-#include "inputleap/clipboard_types.h"
-#include "inputleap/key_types.h"
-#include "inputleap/Fwd.h"
-#include "base/Fwd.h"
 #include "base/Event.h"
 #include "base/EventTarget.h"
+#include "base/Fwd.h"
+#include "inputleap/Fwd.h"
+#include "inputleap/clipboard_types.h"
+#include "inputleap/key_types.h"
+#include <string>
 
 namespace inputleap {
 
@@ -36,8 +37,9 @@ class IStream;
 This class acts a proxy for the server, converting calls into messages
 to the server and messages from the server to calls on the client.
 */
-class ServerProxy : public EventTarget {
-public:
+class ServerProxy : public EventTarget
+{
+  public:
     /*!
     Process messages from the server on \p stream and forward to
     \p client.
@@ -64,12 +66,17 @@ public:
     void handleDataForTest() { handleData(Event(), nullptr); }
 #endif
 
-protected:
-    enum EResult { kOkay, kUnknown, kDisconnect };
+  protected:
+    enum EResult
+    {
+        kOkay,
+        kUnknown,
+        kDisconnect
+    };
     EResult parseHandshakeMessage(const std::uint8_t* code);
     EResult parseMessage(const std::uint8_t* code);
 
-private:
+  private:
     // if compressing mouse motion then send the last motion now
     void flushCompressedMouse();
 
@@ -108,7 +115,7 @@ private:
     void dragInfoReceived();
     void handle_clipboard_sending_event(const Event&);
 
-private:
+  private:
     typedef EResult (ServerProxy::*MessageParser)(const std::uint8_t*);
 
     Client* m_client;
@@ -130,6 +137,9 @@ private:
 
     MessageParser m_parser;
     IEventQueue* m_events;
+    std::string m_disconnectReason;
+
+    void disconnect(const char* reason);
 };
 
 } // namespace inputleap

--- a/src/lib/server/ClientProxy1_6.cpp
+++ b/src/lib/server/ClientProxy1_6.cpp
@@ -19,16 +19,16 @@
 #include "server/ClientProxy1_6.h"
 #include "ClientConnectionByStream.h"
 
-#include "inputleap/ProtocolUtil.h"
+#include "base/EventQueueTimer.h"
+#include "base/IEventQueue.h"
+#include "base/Log.h"
 #include "inputleap/ClipboardChunk.h"
 #include "inputleap/Exceptions.h"
 #include "inputleap/FileChunk.h"
+#include "inputleap/ProtocolUtil.h"
 #include "inputleap/StreamChunker.h"
-#include "server/Server.h"
 #include "io/IStream.h"
-#include "base/Log.h"
-#include "base/IEventQueue.h"
-#include "base/EventQueueTimer.h"
+#include "server/Server.h"
 
 #include <cstring>
 
@@ -36,32 +36,37 @@ namespace inputleap {
 
 ClientProxy1_6::ClientProxy1_6(const std::string& name,
                                std::unique_ptr<IClientConnection> backend,
-                               Server* server, IEventQueue* events) :
-    ClientProxy(name, std::move(backend)),
-    m_heartbeatTimer(nullptr),
-    m_parser(&ClientProxy1_6::parseHandshakeMessage),
-    m_events(events),
-    m_keepAliveRate(kKeepAliveRate),
-    m_keepAliveTimer(nullptr),
-    m_server{server}
+                               Server* server,
+                               IEventQueue* events)
+  : ClientProxy(name, std::move(backend))
+  , m_heartbeatTimer(nullptr)
+  , m_parser(&ClientProxy1_6::parseHandshakeMessage)
+  , m_events(events)
+  , m_keepAliveRate(kKeepAliveRate)
+  , m_keepAliveTimer(nullptr)
+  , m_server{ server }
 {
     // install event handlers
-    m_events->add_handler(EventType::STREAM_INPUT_READY, get_conn().get_event_target(),
-                          [this](const auto& e){ handle_data(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR, get_conn().get_event_target(),
-                          [this](const auto& e){ handle_write_error(); });
-    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN, get_conn().get_event_target(),
-                          [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR, get_conn().get_event_target(),
-                          [this](const auto& e){ handle_disconnect(); });
-    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN, get_conn().get_event_target(),
-                          [this](const auto& e){ handle_write_error(); });
-    m_events->add_handler(EventType::FILE_KEEPALIVE, this,
-                          [this](const auto& e){ keepAlive(); });
-    m_events->add_handler(EventType::CLIPBOARD_SENDING, this,
-                          [this](const auto& e){ handle_clipboard_sending_event(e); });
-    m_events->add_handler(EventType::TIMER, this,
-                          [this](const auto& e){ handle_flatline(); });
+    m_events->add_handler(EventType::STREAM_INPUT_READY,
+                          get_conn().get_event_target(),
+                          [this](const auto& e) { handle_data(); });
+    m_events->add_handler(EventType::STREAM_OUTPUT_ERROR,
+                          get_conn().get_event_target(),
+                          [this](const auto& e) { handle_write_error(); });
+    m_events->add_handler(EventType::STREAM_INPUT_SHUTDOWN,
+                          get_conn().get_event_target(),
+                          [this](const auto& e) { handle_disconnect(); });
+    m_events->add_handler(EventType::STREAM_INPUT_FORMAT_ERROR,
+                          get_conn().get_event_target(),
+                          [this](const auto& e) { handle_disconnect(); });
+    m_events->add_handler(EventType::STREAM_OUTPUT_SHUTDOWN,
+                          get_conn().get_event_target(),
+                          [this](const auto& e) { handle_write_error(); });
+    m_events->add_handler(EventType::FILE_KEEPALIVE, this, [this](const auto& e) { keepAlive(); });
+    m_events->add_handler(EventType::CLIPBOARD_SENDING, this, [this](const auto& e) {
+        handle_clipboard_sending_event(e);
+    });
+    m_events->add_handler(EventType::TIMER, this, [this](const auto& e) { handle_flatline(); });
 
     setHeartbeatRate(kHeartRate, kHeartRate * kHeartBeatsUntilDeath);
 
@@ -75,19 +80,23 @@ ClientProxy1_6::~ClientProxy1_6()
     remove_handlers();
 }
 
-IStream* ClientProxy1_6::getStream() const
+IStream*
+ClientProxy1_6::getStream() const
 {
     return get_conn().get_stream();
 }
 
-void ClientProxy1_6::disconnect()
+void
+ClientProxy1_6::disconnect(const char* reason)
 {
     remove_handlers();
     get_conn().close();
+    (void)reason; // reason currently unused
     m_events->add_event(EventType::CLIENT_PROXY_DISCONNECTED, get_event_target());
 }
 
-void ClientProxy1_6::remove_handlers()
+void
+ClientProxy1_6::remove_handlers()
 {
     // uninstall event handlers
     m_events->remove_handler(EventType::STREAM_INPUT_READY, get_conn().get_event_target());
@@ -103,12 +112,13 @@ void ClientProxy1_6::remove_handlers()
     removeHeartbeatTimer();
 }
 
-void ClientProxy1_6::addHeartbeatTimer()
+void
+ClientProxy1_6::addHeartbeatTimer()
 {
     if (m_keepAliveRate > 0.0) {
         m_keepAliveTimer = m_events->newTimer(m_keepAliveRate, nullptr);
-        m_events->add_handler(EventType::TIMER, m_keepAliveTimer,
-                              [this](const auto& e){ keepAlive(); });
+        m_events->add_handler(
+          EventType::TIMER, m_keepAliveTimer, [this](const auto& e) { keepAlive(); });
     }
 
     if (m_heartbeatAlarm > 0.0) {
@@ -116,7 +126,8 @@ void ClientProxy1_6::addHeartbeatTimer()
     }
 }
 
-void ClientProxy1_6::removeHeartbeatTimer()
+void
+ClientProxy1_6::removeHeartbeatTimer()
 {
     if (m_keepAliveTimer != nullptr) {
         m_events->remove_handler(EventType::TIMER, m_keepAliveTimer);
@@ -130,7 +141,8 @@ void ClientProxy1_6::removeHeartbeatTimer()
     }
 }
 
-void ClientProxy1_6::resetHeartbeatTimer()
+void
+ClientProxy1_6::resetHeartbeatTimer()
 {
     // reset the alarm but not the keep alive timer
     if (m_heartbeatTimer != nullptr) {
@@ -143,18 +155,21 @@ void ClientProxy1_6::resetHeartbeatTimer()
     }
 }
 
-void ClientProxy1_6::resetHeartbeatRate()
+void
+ClientProxy1_6::resetHeartbeatRate()
 {
     setHeartbeatRate(kKeepAliveRate, kKeepAliveRate * kKeepAlivesUntilDeath);
 }
 
-void ClientProxy1_6::setHeartbeatRate(double rate, double alarm)
+void
+ClientProxy1_6::setHeartbeatRate(double rate, double alarm)
 {
     m_keepAliveRate = rate;
     m_heartbeatAlarm = alarm;
 }
 
-void ClientProxy1_6::handle_data()
+void
+ClientProxy1_6::handle_data()
 {
     // handle messages until there are no more.  first read message code.
     std::uint8_t code[4];
@@ -163,24 +178,36 @@ void ClientProxy1_6::handle_data()
         // verify we got an entire code
         if (n != 4) {
             LOG_ERR("incomplete message from \"%s\": %d bytes", getName().c_str(), n);
-            disconnect();
+            disconnect("incomplete message from client");
             return;
         }
 
         // parse message
         try {
-            LOG_DEBUG2("msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
-            if (!(this->*m_parser)(code)) {
-                LOG_ERR("invalid message from client \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
-                disconnect();
-                return;
+            LOG_DEBUG2(
+              "msg from \"%s\": %c%c%c%c", getName().c_str(), code[0], code[1], code[2], code[3]);
+            switch ((this->*m_parser)(code)) {
+                case kOkay:
+                    break;
+                case kUnknown:
+                    LOG_ERR("invalid message from client \"%s\": %c%c%c%c",
+                            getName().c_str(),
+                            code[0],
+                            code[1],
+                            code[2],
+                            code[3]);
+                    disconnect("invalid message from client");
+                    return;
+                case kDisconnect:
+                    disconnect(m_disconnectReason.empty() ? nullptr : m_disconnectReason.c_str());
+                    return;
             }
         } catch (const XBadClient& e) {
             // TODO: disconnect handling is currently dispersed across both parseMessage() and
             // handleData() functions, we should collect that to a single place
 
             LOG_ERR("protocol error from client: %s", e.what());
-            disconnect();
+            disconnect("invalid message from client");
             return;
         }
 
@@ -192,14 +219,14 @@ void ClientProxy1_6::handle_data()
     resetHeartbeatTimer();
 }
 
-bool ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
+ClientProxy1_6::EResult
+ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
         LOG_DEBUG2("no-op from %s", getName().c_str());
-        return true;
-    }
-    else if (memcmp(code, kMsgDInfo, 4) == 0) {
+        return kOkay;
+    } else if (memcmp(code, kMsgDInfo, 4) == 0) {
         // future messages get parsed by parseMessage
         // NOTE: we're taking address of virtual function here,
         // not ClientProxy1_3 implementation of it.
@@ -207,77 +234,89 @@ bool ClientProxy1_6::parseHandshakeMessage(const std::uint8_t* code)
         if (recvInfo()) {
             m_events->add_event(EventType::CLIENT_PROXY_READY, get_event_target());
             addHeartbeatTimer();
-            return true;
+            return kOkay;
         }
+        return kUnknown;
     }
-    return false;
+    return kUnknown;
 }
 
-bool ClientProxy1_6::parseMessage(const std::uint8_t* code)
+ClientProxy1_6::EResult
+ClientProxy1_6::parseMessage(const std::uint8_t* code)
 {
     if (memcmp(code, kMsgDFileTransfer, 4) == 0) {
         fileChunkReceived();
-        return true;
+        return kOkay;
     } else if (memcmp(code, kMsgDDragInfo, 4) == 0) {
         dragInfoReceived();
-        return true;
+        return kOkay;
     } else if (memcmp(code, kMsgCKeepAlive, 4) == 0) {
         // reset alarm
         resetHeartbeatTimer();
-        return true;
+        return kOkay;
     } else if (memcmp(code, kMsgDInfo, 4) == 0) {
         if (recvInfo()) {
             m_events->add_event(EventType::SCREEN_SHAPE_CHANGED, get_event_target());
-            return true;
+            return kOkay;
         }
-        return false;
-    }
-    else if (memcmp(code, kMsgCNoop, 4) == 0) {
+        return kUnknown;
+    } else if (memcmp(code, kMsgCNoop, 4) == 0) {
         // discard no-ops
         LOG_DEBUG2("no-op from %s", getName().c_str());
-        return true;
+        return kOkay;
+    } else if (memcmp(code, kMsgCClipboard, 4) == 0) {
+        return recvGrabClipboard() ? kOkay : kUnknown;
+    } else if (memcmp(code, kMsgDClipboard, 4) == 0) {
+        return recvClipboard() ? kOkay : kUnknown;
+    } else if (memcmp(code, kMsgCClose, 4) == 0) {
+        LOG_DEBUG1("recv close from \"%s\"", getName().c_str());
+        m_disconnectReason.clear();
+        return kDisconnect;
+    } else if (memcmp(code, kMsgEBad, 4) == 0) {
+        LOG_ERR("client \"%s\" reported a protocol error", getName().c_str());
+        m_disconnectReason = "client reported a protocol error";
+        return kDisconnect;
     }
-    else if (memcmp(code, kMsgCClipboard, 4) == 0) {
-        return recvGrabClipboard();
-    }
-    else if (memcmp(code, kMsgDClipboard, 4) == 0) {
-        return recvClipboard();
-    }
-    return false;
+    return kUnknown;
 }
 
-void ClientProxy1_6::handle_disconnect()
+void
+ClientProxy1_6::handle_disconnect()
 {
     LOG_NOTE("client \"%s\" has disconnected", getName().c_str());
-    disconnect();
+    disconnect(nullptr);
 }
 
-void ClientProxy1_6::handle_write_error()
+void
+ClientProxy1_6::handle_write_error()
 {
     LOG_WARN("error writing to client \"%s\"", getName().c_str());
-    disconnect();
+    disconnect(nullptr);
 }
 
-void ClientProxy1_6::handle_flatline()
+void
+ClientProxy1_6::handle_flatline()
 {
     // didn't get a heartbeat fast enough.  assume client is dead.
     LOG_NOTE("client \"%s\" is dead", getName().c_str());
-    disconnect();
+    disconnect(nullptr);
 }
 
-void ClientProxy1_6::handle_clipboard_sending_event(const Event& event)
+void
+ClientProxy1_6::handle_clipboard_sending_event(const Event& event)
 {
     get_conn().send_clipboard_chunk_1_6(event.get_data_as<ClipboardChunk>());
 }
 
-bool ClientProxy1_6::getClipboard(ClipboardID id, IClipboard* clipboard) const
+bool
+ClientProxy1_6::getClipboard(ClipboardID id, IClipboard* clipboard) const
 {
     Clipboard::copy(clipboard, &m_clipboard[id].m_clipboard);
     return true;
 }
 
-void ClientProxy1_6::getShape(std::int32_t& x, std::int32_t& y, std::int32_t& w,
-                              std::int32_t& h) const
+void
+ClientProxy1_6::getShape(std::int32_t& x, std::int32_t& y, std::int32_t& w, std::int32_t& h) const
 {
     x = m_info.m_x;
     y = m_info.m_y;
@@ -285,27 +324,34 @@ void ClientProxy1_6::getShape(std::int32_t& x, std::int32_t& y, std::int32_t& w,
     h = m_info.m_h;
 }
 
-void ClientProxy1_6::getCursorPos(std::int32_t& x, std::int32_t& y) const
+void
+ClientProxy1_6::getCursorPos(std::int32_t& x, std::int32_t& y) const
 {
     // note -- this returns the cursor pos from when we last got client info
     x = m_info.m_mx;
     y = m_info.m_my;
 }
 
-void ClientProxy1_6::enter(std::int32_t xAbs, std::int32_t yAbs, std::uint32_t seqNum,
-                           KeyModifierMask mask, bool)
+void
+ClientProxy1_6::enter(std::int32_t xAbs,
+                      std::int32_t yAbs,
+                      std::uint32_t seqNum,
+                      KeyModifierMask mask,
+                      bool)
 {
     get_conn().send_enter_1_6(xAbs, yAbs, seqNum, mask);
 }
 
-bool ClientProxy1_6::leave()
+bool
+ClientProxy1_6::leave()
 {
     get_conn().send_leave_1_6();
     // we can never prevent the user from leaving
     return true;
 }
 
-void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
+void
+ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
 {
     // ignore if this clipboard is already clean
     if (m_clipboard[id].m_dirty) {
@@ -322,7 +368,8 @@ void ClientProxy1_6::setClipboard(ClipboardID id, const IClipboard* clipboard)
     }
 }
 
-void ClientProxy1_6::grabClipboard(ClipboardID id)
+void
+ClientProxy1_6::grabClipboard(ClipboardID id)
 {
     get_conn().send_grab_clipboard(id);
 
@@ -330,69 +377,81 @@ void ClientProxy1_6::grabClipboard(ClipboardID id)
     m_clipboard[id].m_dirty = true;
 }
 
-void ClientProxy1_6::setClipboardDirty(ClipboardID id, bool dirty)
+void
+ClientProxy1_6::setClipboardDirty(ClipboardID id, bool dirty)
 {
     m_clipboard[id].m_dirty = dirty;
 }
 
-void ClientProxy1_6::keyDown(KeyID key, KeyModifierMask mask, KeyButton button)
+void
+ClientProxy1_6::keyDown(KeyID key, KeyModifierMask mask, KeyButton button)
 {
     get_conn().send_key_down_1_6(key, mask, button);
 }
 
-void ClientProxy1_6::keyRepeat(KeyID key, KeyModifierMask mask, std::int32_t count,
-                               KeyButton button)
+void
+ClientProxy1_6::keyRepeat(KeyID key, KeyModifierMask mask, std::int32_t count, KeyButton button)
 {
     get_conn().send_key_repeat_1_6(key, mask, count, button);
 }
 
-void ClientProxy1_6::keyUp(KeyID key, KeyModifierMask mask, KeyButton button)
+void
+ClientProxy1_6::keyUp(KeyID key, KeyModifierMask mask, KeyButton button)
 {
     get_conn().send_key_up_1_6(key, mask, button);
 }
 
-void ClientProxy1_6::mouseDown(ButtonID button)
+void
+ClientProxy1_6::mouseDown(ButtonID button)
 {
     get_conn().send_mouse_down_1_6(button);
 }
 
-void ClientProxy1_6::mouseUp(ButtonID button)
+void
+ClientProxy1_6::mouseUp(ButtonID button)
 {
     get_conn().send_mouse_up_1_6(button);
 }
 
-void ClientProxy1_6::mouseMove(std::int32_t xAbs, std::int32_t yAbs)
+void
+ClientProxy1_6::mouseMove(std::int32_t xAbs, std::int32_t yAbs)
 {
     get_conn().send_mouse_move_1_6(xAbs, yAbs);
 }
 
-void ClientProxy1_6::mouseRelativeMove(std::int32_t xRel, std::int32_t yRel)
+void
+ClientProxy1_6::mouseRelativeMove(std::int32_t xRel, std::int32_t yRel)
 {
     get_conn().send_mouse_relative_move_1_6(xRel, yRel);
 }
 
-void ClientProxy1_6::mouseWheel(std::int32_t xDelta, std::int32_t yDelta)
+void
+ClientProxy1_6::mouseWheel(std::int32_t xDelta, std::int32_t yDelta)
 {
     get_conn().send_mouse_wheel_1_6(xDelta, yDelta);
 }
 
-void ClientProxy1_6::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)
+void
+ClientProxy1_6::sendDragInfo(std::uint32_t fileCount, const char* info, size_t size)
 {
     std::string data(info, size);
     get_conn().send_drag_info_1_6(fileCount, data);
 }
 
-void ClientProxy1_6::file_chunk_sending(const FileChunk& chunk)
+void
+ClientProxy1_6::file_chunk_sending(const FileChunk& chunk)
 {
     get_conn().send_file_chunk_1_6(chunk);
 }
 
-void ClientProxy1_6::screensaver(bool on)
+void
+ClientProxy1_6::screensaver(bool on)
 {
     get_conn().send_screensaver_1_6(on);
 }
 
-void ClientProxy1_6::resetOptions()
+void
+ClientProxy1_6::resetOptions()
 {
     get_conn().send_reset_options_1_6();
     // reset heart rate and death
@@ -401,7 +460,8 @@ void ClientProxy1_6::resetOptions()
     addHeartbeatTimer();
 }
 
-void ClientProxy1_6::setOptions(const OptionsList& options)
+void
+ClientProxy1_6::setOptions(const OptionsList& options)
 {
     get_conn().send_set_options_1_6(options);
 
@@ -419,15 +479,22 @@ void ClientProxy1_6::setOptions(const OptionsList& options)
     }
 }
 
-bool ClientProxy1_6::recvInfo()
+bool
+ClientProxy1_6::recvInfo()
 {
     // parse the message
     std::int16_t x, y, w, h, dummy1, mx, my;
-    if (!ProtocolUtil::readf(getStream(), kMsgDInfo + 4,
-                            &x, &y, &w, &h, &dummy1, &mx, &my)) {
+    if (!ProtocolUtil::readf(getStream(), kMsgDInfo + 4, &x, &y, &w, &h, &dummy1, &mx, &my)) {
         return false;
     }
-    LOG_DEBUG("received client \"%s\" info shape=%d,%d %dx%d at %d,%d", getName().c_str(), x, y, w, h, mx, my);
+    LOG_DEBUG("received client \"%s\" info shape=%d,%d %dx%d at %d,%d",
+              getName().c_str(),
+              x,
+              y,
+              w,
+              h,
+              mx,
+              my);
 
     // validate
     if (w <= 0 || h <= 0) {
@@ -439,10 +506,10 @@ bool ClientProxy1_6::recvInfo()
     }
 
     // save
-    m_info.m_x  = x;
-    m_info.m_y  = y;
-    m_info.m_w  = w;
-    m_info.m_h  = h;
+    m_info.m_x = x;
+    m_info.m_y = y;
+    m_info.m_w = w;
+    m_info.m_h = h;
     m_info.m_mx = mx;
     m_info.m_my = my;
 
@@ -451,7 +518,8 @@ bool ClientProxy1_6::recvInfo()
     return true;
 }
 
-bool ClientProxy1_6::recvClipboard()
+bool
+ClientProxy1_6::recvClipboard()
 {
     // parse message
     static std::string dataCached;
@@ -465,7 +533,10 @@ bool ClientProxy1_6::recvClipboard()
         LOG_DEBUG("receiving clipboard %d size=%zd", id, size);
     } else if (r == kFinish) {
         LOG_DEBUG("received client \"%s\" clipboard %d seqnum=%d, size=%zd",
-                getName().c_str(), id, seq, dataCached.size());
+                  getName().c_str(),
+                  id,
+                  seq,
+                  dataCached.size());
         // save clipboard
         m_clipboard[id].m_clipboard.unmarshall(dataCached, 0);
         m_clipboard[id].m_sequenceNumber = seq;
@@ -474,14 +545,15 @@ bool ClientProxy1_6::recvClipboard()
         ClipboardInfo info;
         info.m_id = id;
         info.m_sequenceNumber = seq;
-        m_events->add_event(EventType::CLIPBOARD_CHANGED, get_event_target(),
-                            create_event_data<ClipboardInfo>(info));
+        m_events->add_event(
+          EventType::CLIPBOARD_CHANGED, get_event_target(), create_event_data<ClipboardInfo>(info));
     }
 
     return true;
 }
 
-bool ClientProxy1_6::recvGrabClipboard()
+bool
+ClientProxy1_6::recvGrabClipboard()
 {
     // parse message
     ClipboardID id;
@@ -489,7 +561,8 @@ bool ClientProxy1_6::recvGrabClipboard()
     if (!ProtocolUtil::readf(getStream(), kMsgCClipboard + 4, &id, &seqNum)) {
         return false;
     }
-    LOG_DEBUG("received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum);
+    LOG_DEBUG(
+      "received client \"%s\" grabbed clipboard %d seqnum=%d", getName().c_str(), id, seqNum);
 
     // validate
     if (id >= kClipboardEnd) {
@@ -500,22 +573,24 @@ bool ClientProxy1_6::recvGrabClipboard()
     ClipboardInfo info;
     info.m_id = id;
     info.m_sequenceNumber = seqNum;
-    m_events->add_event(EventType::CLIPBOARD_GRABBED, get_event_target(),
-                        create_event_data<ClipboardInfo>(info));
+    m_events->add_event(
+      EventType::CLIPBOARD_GRABBED, get_event_target(), create_event_data<ClipboardInfo>(info));
 
     return true;
 }
 
-void ClientProxy1_6::keepAlive()
+void
+ClientProxy1_6::keepAlive()
 {
     get_conn().send_keep_alive_1_6();
 }
 
-void ClientProxy1_6::fileChunkReceived()
+void
+ClientProxy1_6::fileChunkReceived()
 {
     Server* server = getServer();
-    int result = FileChunk::assemble(getStream(), server->getReceivedFileData(),
-                                     server->getExpectedFileSize());
+    int result = FileChunk::assemble(
+      getStream(), server->getReceivedFileData(), server->getExpectedFileSize());
 
     if (result == kFinish) {
         m_events->add_event(EventType::FILE_RECEIVE_COMPLETED, server);
@@ -527,7 +602,8 @@ void ClientProxy1_6::fileChunkReceived()
     }
 }
 
-void ClientProxy1_6::dragInfoReceived()
+void
+ClientProxy1_6::dragInfoReceived()
 {
     // parse
     std::uint32_t fileNum = 0;
@@ -537,10 +613,10 @@ void ClientProxy1_6::dragInfoReceived()
     m_server->dragInfoReceived(fileNum, content);
 }
 
-ClientProxy1_6::ClientClipboard::ClientClipboard() :
-    m_clipboard(),
-    m_sequenceNumber(0),
-    m_dirty(true)
+ClientProxy1_6::ClientClipboard::ClientClipboard()
+  : m_clipboard()
+  , m_sequenceNumber(0)
+  , m_dirty(true)
 {
     // do nothing
 }

--- a/src/lib/server/ClientProxy1_6.h
+++ b/src/lib/server/ClientProxy1_6.h
@@ -18,10 +18,11 @@
 
 #pragma once
 
-#include "server/ClientProxy.h"
 #include "base/Fwd.h"
 #include "inputleap/Clipboard.h"
 #include "inputleap/protocol_types.h"
+#include "server/ClientProxy.h"
+#include <string>
 
 namespace inputleap {
 
@@ -29,10 +30,13 @@ class Server;
 class IStream;
 
 //! Proxy for client implementing protocol version 1.0
-class ClientProxy1_6 : public ClientProxy {
-public:
-    ClientProxy1_6(const std::string& name, std::unique_ptr<IClientConnection> backend,
-                   Server* server, IEventQueue* events);
+class ClientProxy1_6 : public ClientProxy
+{
+  public:
+    ClientProxy1_6(const std::string& name,
+                   std::unique_ptr<IClientConnection> backend,
+                   Server* server,
+                   IEventQueue* events);
     ~ClientProxy1_6() override;
 
     Server* getServer() { return m_server; }
@@ -41,12 +45,17 @@ public:
 
     // IScreen
     bool getClipboard(ClipboardID id, IClipboard*) const override;
-    void getShape(std::int32_t& x, std::int32_t& y, std::int32_t& width,
+    void getShape(std::int32_t& x,
+                  std::int32_t& y,
+                  std::int32_t& width,
                   std::int32_t& height) const override;
     void getCursorPos(std::int32_t& x, std::int32_t& y) const override;
 
     // IClient overrides
-    void enter(std::int32_t xAbs, std::int32_t yAbs, std::uint32_t seqNum, KeyModifierMask mask,
+    void enter(std::int32_t xAbs,
+               std::int32_t yAbs,
+               std::uint32_t seqNum,
+               KeyModifierMask mask,
                bool forScreensaver) override;
     bool leave() override;
     void setClipboard(ClipboardID, const IClipboard*) override;
@@ -66,9 +75,15 @@ public:
     void sendDragInfo(std::uint32_t fileCount, const char* info, size_t size) override;
     void file_chunk_sending(const FileChunk& chunk) override;
 
-protected:
-    virtual bool parseHandshakeMessage(const std::uint8_t* code);
-    virtual bool parseMessage(const std::uint8_t* code);
+  protected:
+    enum EResult
+    {
+        kOkay,
+        kUnknown,
+        kDisconnect
+    };
+    virtual EResult parseHandshakeMessage(const std::uint8_t* code);
+    virtual EResult parseMessage(const std::uint8_t* code);
 
     virtual void resetHeartbeatRate();
     virtual void setHeartbeatRate(double rate, double alarm);
@@ -81,8 +96,8 @@ protected:
     void fileChunkReceived();
     void dragInfoReceived();
 
-private:
-    void disconnect();
+  private:
+    void disconnect(const char* reason);
     void remove_handlers();
 
     void handle_data();
@@ -94,12 +109,13 @@ private:
     bool recvInfo();
     bool recvGrabClipboard();
 
-protected:
-    struct ClientClipboard {
-    public:
+  protected:
+    struct ClientClipboard
+    {
+      public:
         ClientClipboard();
 
-    public:
+      public:
         Clipboard m_clipboard;
         std::uint32_t m_sequenceNumber;
         bool m_dirty;
@@ -107,8 +123,8 @@ protected:
 
     ClientClipboard m_clipboard[kClipboardEnd];
 
-protected:
-    typedef bool (ClientProxy1_6::*MessageParser)(const std::uint8_t*);
+  protected:
+    typedef EResult (ClientProxy1_6::*MessageParser)(const std::uint8_t*);
 
     ClientInfo m_info;
     double m_heartbeatAlarm;
@@ -119,6 +135,7 @@ protected:
     double m_keepAliveRate;
     EventQueueTimer* m_keepAliveTimer;
     Server* m_server;
+    std::string m_disconnectReason;
 };
 
 } // namespace inputleap


### PR DESCRIPTION
## Summary
- Centralize server proxy disconnects and have parsing methods report result codes
- Adopt the same pattern for 1.6 client proxy

## Testing
- `cmake -S . -B build` *(passed)*
- `cmake --build build` *(interrupted at ~68% due to time)*

------
https://chatgpt.com/codex/tasks/task_b_68a96a49cb248325a71f792b207ab8e5