### PR TITLE
Centralize disconnect handling and add tests

### DIFF
--- a/src/lib/client/ServerProxy.cpp
+++ b/src/lib/client/ServerProxy.cpp
@@ -103,6 +103,12 @@ ServerProxy::setKeepAliveRate(double rate)
 }
 
 void
+ServerProxy::handleDisconnect()
+{
+    disconnect(m_disconnectReason.empty() ? nullptr : m_disconnectReason.c_str());
+}
+
+void
 ServerProxy::handle_data()
 {
     // handle messages until there are no more.  first read message code.
@@ -112,7 +118,8 @@ ServerProxy::handle_data()
         // verify we got an entire code
         if (n != 4) {
             LOG_ERR("incomplete message from server: %d bytes", n);
-            disconnect("incomplete message from server");
+            m_disconnectReason = "incomplete message from server";
+            handleDisconnect();
             return;
         }
 
@@ -126,22 +133,21 @@ ServerProxy::handle_data()
                 case kUnknown:
                     LOG_ERR(
                       "invalid message from server: %c%c%c%c", code[0], code[1], code[2], code[3]);
-                    disconnect("invalid message from server");
+                    m_disconnectReason = "invalid message from server";
+                    handleDisconnect();
                     return;
 
                 case kDisconnect:
-                    disconnect(m_disconnectReason.empty() ? nullptr : m_disconnectReason.c_str());
+                    handleDisconnect();
                     return;
                 default:
                     break;
             }
         } catch (const XBadClient& e) {
-            // TODO: disconnect handling is currently dispersed across both parseMessage() and
-            // handleData() functions, we should collect that to a single place
-
             LOG_ERR("protocol error from server: %s", e.what());
             ProtocolUtil::writef(m_stream, kMsgEBad);
-            disconnect("invalid message from server");
+            m_disconnectReason = "invalid message from server";
+            handleDisconnect();
             return;
         }
 
@@ -340,7 +346,8 @@ void
 ServerProxy::handle_keep_alive_alarm()
 {
     LOG_NOTE("server is dead");
-    disconnect("server is not responding");
+    m_disconnectReason = "server is not responding";
+    handleDisconnect();
 }
 
 void

--- a/src/lib/client/ServerProxy.h
+++ b/src/lib/client/ServerProxy.h
@@ -84,6 +84,7 @@ class ServerProxy : public EventTarget
 
     void resetKeepAliveAlarm();
     void setKeepAliveRate(double);
+    void handleDisconnect();
 
     // modifier key translation
     KeyID translateKey(KeyID) const;

--- a/src/test/unittests/client/ServerProxyTests.cpp
+++ b/src/test/unittests/client/ServerProxyTests.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#define private public
+#include "client/ServerProxy.h"
+#include "test/global/TestEventQueue.h"
+#undef private
+
+#include "client/Client.h"
+#include "inputleap/ClientArgs.h"
+#include "net/NetworkAddress.h"
+#include "net/ISocketFactory.h"
+#include "test/mock/io/MockStream.h"
+#include "test/mock/inputleap/MockScreen.h"
+#include "inputleap/protocol_types.h"
+#include <cstring>
+
+using namespace testing;
+
+namespace inputleap {
+
+class DummySocketFactory : public ISocketFactory {
+public:
+    std::unique_ptr<IDataSocket> create(IArchNetwork::EAddressFamily, ConnectionSecurityLevel) const override { return {}; }
+    std::unique_ptr<IListenSocket> create_listen(IArchNetwork::EAddressFamily, ConnectionSecurityLevel) const override { return {}; }
+};
+
+class ServerProxyTest : public ::testing::Test {
+protected:
+    TestEventQueue events_;
+    MockStream stream_;
+    MockScreen screen_;
+    DummySocketFactory* socketFactory_ = nullptr;
+    Client* client_ = nullptr;
+    ServerProxy* proxy_ = nullptr;
+
+    void SetUp() override {
+        events_.is_ready_ = true;
+        EXPECT_CALL(stream_, get_event_target()).WillRepeatedly(Return(&stream_));
+        socketFactory_ = new DummySocketFactory();
+        ClientArgs args;
+        client_ = new Client(&events_, "test", NetworkAddress(), socketFactory_, &screen_, args);
+        client_->m_mock = true;
+        proxy_ = new ServerProxy(client_, &stream_, &events_);
+        proxy_->m_parser = &ServerProxy::parseMessage;
+    }
+
+    void TearDown() override {
+        delete proxy_;
+        delete client_;
+        delete socketFactory_;
+    }
+};
+
+TEST_F(ServerProxyTest, InvalidMessageDisconnects) {
+    uint8_t code[4] = {'X', 'X', 'X', 'X'};
+    EXPECT_CALL(stream_, read(_, 4))
+        .WillOnce(DoAll(SetArrayArgument<0>(code, code + 4), Return(4)));
+
+    std::string reason;
+    events_.add_handler(EventType::CLIENT_CONNECTION_FAILED, client_->get_event_target(),
+                         [&reason](const auto& e) { reason = e.get_data_as<Client::FailInfo>().m_what; });
+
+    proxy_->handle_data();
+
+    Event ev;
+    ASSERT_TRUE(events_.getEvent(ev, 0.0));
+    events_.dispatchEvent(ev);
+
+    EXPECT_EQ("invalid message from server", proxy_->m_disconnectReason);
+    EXPECT_EQ("invalid message from server", reason);
+}
+
+TEST_F(ServerProxyTest, ProtocolErrorMessageDisconnects) {
+    uint8_t code[4];
+    memcpy(code, kMsgEBad, 4);
+    EXPECT_CALL(stream_, read(_, 4))
+        .WillOnce(DoAll(SetArrayArgument<0>(code, code + 4), Return(4)));
+
+    std::string reason;
+    events_.add_handler(EventType::CLIENT_CONNECTION_FAILED, client_->get_event_target(),
+                         [&reason](const auto& e) { reason = e.get_data_as<Client::FailInfo>().m_what; });
+
+    proxy_->handle_data();
+
+    Event ev;
+    ASSERT_TRUE(events_.getEvent(ev, 0.0));
+    events_.dispatchEvent(ev);
+
+    EXPECT_EQ("server reported a protocol error", proxy_->m_disconnectReason);
+    EXPECT_EQ("server reported a protocol error", reason);
+}
+
+} // namespace inputleap
+


### PR DESCRIPTION
## Summary
- Centralize all server disconnect paths into `handleDisconnect`
- Ensure disconnect reasons are set before disconnecting
- Add unit tests for invalid messages and protocol error disconnects

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF` *(fails: The following required packages were not found: xrandr, xinerama, xtst, xi)*

------
https://chatgpt.com/codex/tasks/task_b_68a970a2e7c883258fd246e6e36bde63