### PR TITLE
refactor drag info handling into shared utility

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -38,6 +38,7 @@
 #include "net/ISocketFactory.h"
 #include "net/SecureSocket.h"
 #include "net/TCPSocket.h"
+#include <utility>
 
 #include <climits>
 #include <cstdlib>
@@ -779,15 +780,8 @@ Client::write_to_drop_dir_thread()
 void
 Client::dragInfoReceived(std::uint32_t fileNum, std::string data)
 {
-    // TODO: fix duplicate function from CServer
-    if (!m_args.m_enableDragDrop) {
-        LOG_DEBUG("drag drop not enabled, ignoring drag info.");
-        return;
-    }
-
-    DragInformation::parseDragInfo(m_dragFileList, fileNum, data);
-
-    m_screen->startDraggingFiles(m_dragFileList);
+    DragInformation::handleDragInfo(
+        m_screen, m_dragFileList, m_args.m_enableDragDrop, fileNum, std::move(data));
 }
 
 bool

--- a/src/lib/inputleap/DragInformation.cpp
+++ b/src/lib/inputleap/DragInformation.cpp
@@ -17,10 +17,12 @@
 
 #include "inputleap/DragInformation.h"
 #include "base/Log.h"
+#include "inputleap/Screen.h"
 
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 namespace inputleap {
 
@@ -28,6 +30,21 @@ DragInformation::DragInformation() :
     m_filename(),
     m_filesize(0)
 {
+}
+
+void DragInformation::handleDragInfo(Screen* screen,
+                                     DragFileList& dragFileList,
+                                     bool enableDragDrop,
+                                     std::uint32_t fileNum,
+                                     std::string data)
+{
+    if (!enableDragDrop) {
+        LOG_DEBUG("drag drop not enabled, ignoring drag info.");
+        return;
+    }
+
+    parseDragInfo(dragFileList, fileNum, std::move(data));
+    screen->startDraggingFiles(dragFileList);
 }
 
 void DragInformation::parseDragInfo(DragFileList& dragFileList, std::uint32_t fileNum,

--- a/src/lib/inputleap/DragInformation.h
+++ b/src/lib/inputleap/DragInformation.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include "base/EventTypes.h"
+#include "inputleap/Fwd.h"
 #include <string>
 #include <vector>
 
 namespace inputleap {
 
 class DragInformation;
+class Screen;
 typedef std::vector<DragInformation> DragFileList;
 
 class DragInformation {
@@ -38,6 +40,11 @@ public:
 
     static void parseDragInfo(DragFileList& dragFileList, std::uint32_t fileNum, std::string data);
     static std::string getDragFileExtension(std::string filename);
+    static void handleDragInfo(Screen* screen,
+                               DragFileList& dragFileList,
+                               bool enableDragDrop,
+                               std::uint32_t fileNum,
+                               std::string data);
     // helper function to setup drag info
     // example: filename1,filesize1,filename2,filesize2,
     // return file count

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -38,6 +38,7 @@
 #include "net/IListenSocket.h"
 #include "net/XSocket.h"
 #include "mt/Thread.h"
+#include <utility>
 #include "arch/Arch.h"
 #include "base/EventQueueTimer.h"
 #include "base/IEventQueue.h"
@@ -2238,14 +2239,8 @@ void Server::send_file_thread(const char* filename)
 
 void Server::dragInfoReceived(std::uint32_t fileNum, std::string content)
 {
-	if (!m_args.m_enableDragDrop) {
-		LOG_DEBUG("drag drop not enabled, ignoring drag info.");
-		return;
-	}
-
-	DragInformation::parseDragInfo(m_fakeDragFileList, fileNum, content);
-
-	m_screen->startDraggingFiles(m_fakeDragFileList);
+        DragInformation::handleDragInfo(
+            m_screen, m_fakeDragFileList, m_args.m_enableDragDrop, fileNum, std::move(content));
 }
 
 } // namespace inputleap


### PR DESCRIPTION
## Summary
- add DragInformation::handleDragInfo to centralize drag-and-drop info parsing
- use DragInformation::handleDragInfo in client and server

## Testing
- `cmake --build build --target integtests`
- `./bin/integtests`


------
https://chatgpt.com/codex/tasks/task_b_68a978f3d0848325ab6b9f1a04bbe9a8