### PR TITLE
docs: add safety analysis

### DIFF
--- a/ANALYSIS-SAFETY.md
+++ b/ANALYSIS-SAFETY.md
@@ -1,0 +1,44 @@
+# Summary
+Input Leap is an open-source, cross-platform tool that lets a single keyboard and mouse control multiple computers over the network, mimicking a software KVM switch. The codebase follows typical C++/Qt practices and implements optional TLS encryption and fingerprint validation. No direct evidence of malicious intent was found, though secure operation depends on proper configuration.
+
+# Go / No-Go Recommendation
+**Go** – The repository appears suitable for further use or review. Standard build scripts, clear licensing, and absence of obfuscated code indicate low risk. Users should still enable encryption and manage certificates to avoid network exposure.
+
+# Analysis Criteria
+- Code quality and security practices
+- Dependencies (third-party libraries)
+- Documentation completeness and accuracy
+- Configuration and deployment scripts
+- Project and commit history
+
+# Detailed Findings
+## Code quality and security practices
+- Configuration defaults initialise cryptography off in the constructor but enable it by default when settings are loaded; client certificates remain optional, leaving room for unencrypted or unauthenticated sessions if users disable them【F:src/gui/src/AppConfig.cpp†L50-L64】【F:src/gui/src/AppConfig.cpp†L141-L166】
+- Network connections rely on OpenSSL and custom SSL handling, indicating support for TLS-secured communication【F:src/lib/net/SecureSocket.cpp†L18-L38】
+- A fingerprint database is used to store and compare trusted certificate fingerprints to mitigate man-in-the-middle risks【F:src/lib/net/FingerprintDatabase.cpp†L26-L90】
+- Search for system-level command execution found only GUI dialog invocations, with no evidence of shell execution or `system()` calls【326426†L1-L15】
+
+## Dependencies
+- The build system exposes options for GUI, tests, X11, libei, and internal filesystem support, showing explicit dependency management【F:CMakeLists.txt†L25-L32】
+- Bundled third-party components include Google Test and gulrak-filesystem libraries【019663†L1-L3】
+
+## Documentation completeness and accuracy
+- The README clearly states the project’s purpose as a software KVM and outlines basic usage and goals【F:README.md†L10-L41】
+
+## Configuration and deployment scripts
+- `clean_build.sh` bootstraps the environment, updates submodules, and builds using CMake and, when available, Ninja【F:clean_build.sh†L1-L60】
+
+## Project and commit history
+- Recent commits are transparent merges and documentation updates; no suspicious or obfuscated commit messages were observed【3d51dd†L1-L20】
+
+# Reasoning
+The presence of OpenSSL-based security features and a fingerprint database suggests deliberate effort toward secure communication, but optional client certificates and user-controlled encryption mean misconfiguration could expose input or clipboard data. No obvious malicious code or hidden functionality was detected, and dependencies are declared explicitly, supporting the Go recommendation.
+
+# Recommendations
+- Enforce encrypted connections and consider requiring client certificates by default.
+- Monitor and update third-party dependencies (Qt, OpenSSL, gtest) to patch known vulnerabilities.
+- Expand automated tests, particularly around security features and network handling.
+- Clarify documentation on security implications of disabling encryption and certificate checks.
+
+# Error Handling
+All repository content was accessible. No build or runtime tests were executed in this review; further evaluation may require compiling and running the software to assess runtime behaviour.


### PR DESCRIPTION
## Summary
- add safety analysis report covering code, dependencies, docs, build scripts, and commit history

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68aa68cd06348325a88b18bd6b9fc29b