### PR TITLE
Check daemon setup errors

### DIFF
--- a/src/lib/arch/unix/ArchDaemonUnix.cpp
+++ b/src/lib/arch/unix/ArchDaemonUnix.cpp
@@ -18,22 +18,52 @@
 
 #include "arch/unix/ArchDaemonUnix.h"
 
-#include "arch/unix/XArchUnix.h"
 #include "arch/XArch.h"
+#include "arch/unix/XArchUnix.h"
 #include "base/Log.h"
 
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
 #include <cstdlib>
+#include <errno.h>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #ifdef __APPLE__
 extern char** NXArgv;
 #endif
 
 namespace inputleap {
+
+namespace {
+
+pid_t (*g_fork)() = ::fork;
+int (*g_setsid)() = ::setsid;
+int (*g_open)(const char*, int, ...) = ::open;
+int (*g_dup)(int) = ::dup;
+int (*g_chdir)(const char*) = ::chdir;
+int (*g_close)(int) = ::close;
+
+} // namespace
+
+#if defined(INPUTLEAP_BUILD_TESTS)
+void
+setArchDaemonUnixHooks(pid_t (*forkHook)(),
+                       int (*setsidHook)(),
+                       int (*openHook)(const char*, int, ...),
+                       int (*dupHook)(int),
+                       int (*chdirHook)(const char*),
+                       int (*closeHook)(int))
+{
+    g_fork = forkHook ? forkHook : ::fork;
+    g_setsid = setsidHook ? setsidHook : ::setsid;
+    g_open = openHook ? openHook : ::open;
+    g_dup = dupHook ? dupHook : ::dup;
+    g_chdir = chdirHook ? chdirHook : ::chdir;
+    g_close = closeHook ? closeHook : ::close;
+}
+#endif
 
 ArchDaemonUnix::ArchDaemonUnix()
 {
@@ -44,7 +74,6 @@ ArchDaemonUnix::~ArchDaemonUnix()
 {
     // do nothing
 }
-
 
 #ifdef __APPLE__
 
@@ -62,7 +91,9 @@ execSelfNonDaemonized()
     return 0;
 }
 
-bool alreadyDaemonized() {
+bool
+alreadyDaemonized()
+{
     return std::getenv("_INPUTLEAP_DAEMONIZED") != nullptr;
 }
 
@@ -78,51 +109,67 @@ ArchDaemonUnix::daemonize(const char* name, DaemonFunc func)
 
     // fork so shell thinks we're done and so we're not a process
     // group leader
-    switch (fork()) {
-    case -1:
-        // failed
-        throw XArchDaemonFailed(error_code_to_string_errno(errno));
+    switch (g_fork()) {
+        case -1:
+            // failed
+            throw XArchDaemonFailed(error_code_to_string_errno(errno));
 
-    case 0:
-        // child
-        break;
+        case 0:
+            // child
+            break;
 
-    default:
-        // parent exits
-        exit(0);
+        default:
+            // parent exits
+            exit(0);
     }
 
     // become leader of a new session
-    setsid();
+    if (g_setsid() < 0) {
+        std::string err = error_code_to_string_errno(errno);
+        LOG_ERR("setsid error: %s", err.c_str());
+        throw XArchDaemonFailed(err);
+    }
 
 #ifndef __APPLE__
     // NB: don't run chdir on apple; causes strange behaviour.
     // chdir to root so we don't keep mounted filesystems points busy
     // TODO: this is a bit of a hack - can we find a better solution?
-    int chdirErr = chdir("/");
-    if (chdirErr)
-        // NB: file logging actually isn't working at this point!
-        LOG_ERR("chdir error: %i", chdirErr);
+    int chdirErr = g_chdir("/");
+    if (chdirErr) {
+        std::string err = error_code_to_string_errno(errno);
+        LOG_ERR("chdir error: %s", err.c_str());
+        throw XArchDaemonFailed(err);
+    }
 #endif
 
     // mask off permissions for any but owner
     umask(077);
 
     // close open files.  we only expect stdin, stdout, stderr to be open.
-    close(0);
-    close(1);
-    close(2);
+    g_close(0);
+    g_close(1);
+    g_close(2);
 
     // attach file descriptors 0, 1, 2 to /dev/null so inadvertent use
     // of standard I/O safely goes in the bit bucket.
-    open("/dev/null", O_RDONLY);
-    open("/dev/null", O_RDWR);
+    int fd = g_open("/dev/null", O_RDONLY);
+    if (fd < 0) {
+        std::string err = error_code_to_string_errno(errno);
+        LOG_ERR("open error: %s", err.c_str());
+        throw XArchDaemonFailed(err);
+    }
+    fd = g_open("/dev/null", O_RDWR);
+    if (fd < 0) {
+        std::string err = error_code_to_string_errno(errno);
+        LOG_ERR("open error: %s", err.c_str());
+        throw XArchDaemonFailed(err);
+    }
 
-    int dupErr = dup(1);
-
+    int dupErr = g_dup(1);
     if (dupErr < 0) {
-        // NB: file logging actually isn't working at this point!
-        LOG_ERR("dup error: %i", dupErr);
+        std::string err = error_code_to_string_errno(errno);
+        LOG_ERR("dup error: %s", err.c_str());
+        throw XArchDaemonFailed(err);
     }
 
 #ifdef __APPLE__

--- a/src/test/unittests/CMakeLists.txt
+++ b/src/test/unittests/CMakeLists.txt
@@ -48,9 +48,13 @@ if (BUILD_XWINDOWS)
     file(GLOB portal_sources "platform/Portal*.cpp")
     file(GLOB portal_headers "platform/Portal*.h")
 endif()
+if (UNIX)
+    file(GLOB daemon_unix_sources "platform/ArchDaemonUnix*.cpp")
+    file(GLOB daemon_unix_headers "platform/ArchDaemonUnix*.h")
+endif()
 
-list(APPEND sources ${mswin_sources} ${carbon_sources} ${xwin_sources} ${portal_sources})
-list(APPEND headers ${mswin_headers} ${carbon_headers} ${xwin_headers} ${portal_headers})
+list(APPEND sources ${mswin_sources} ${carbon_sources} ${xwin_sources} ${portal_sources} ${daemon_unix_sources})
+list(APPEND headers ${mswin_headers} ${carbon_headers} ${xwin_headers} ${portal_headers} ${daemon_unix_headers})
 
 include_directories(
     ../../

--- a/src/test/unittests/platform/ArchDaemonUnixTests.cpp
+++ b/src/test/unittests/platform/ArchDaemonUnixTests.cpp
@@ -1,0 +1,153 @@
+/*
+ * InputLeap -- mouse and keyboard sharing utility
+ * Copyright (C) 2024
+ */
+
+#include "arch/XArch.h"
+#include "arch/unix/ArchDaemonUnix.h"
+
+#include <cerrno>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using inputleap::ArchDaemonUnix;
+using inputleap::XArchDaemonFailed;
+
+namespace {
+
+int
+dummyFunc(int, const char**)
+{
+    return 0;
+}
+
+pid_t
+forkStub()
+{
+    return 0;
+}
+int
+closeStub(int)
+{
+    return 0;
+}
+
+int
+setsidFail()
+{
+    errno = EPERM;
+    return -1;
+}
+int
+setsidOk()
+{
+    return 1;
+}
+
+int
+chdirFail(const char*)
+{
+    errno = EIO;
+    return -1;
+}
+int
+chdirOk(const char*)
+{
+    return 0;
+}
+
+int
+openFail(const char*, int, ...)
+{
+    errno = EMFILE;
+    return -1;
+}
+
+int openFailSecondCount = 0;
+int
+openFailSecond(const char*, int, ...)
+{
+    ++openFailSecondCount;
+    if (openFailSecondCount == 2) {
+        errno = EMFILE;
+        return -1;
+    }
+    return 3;
+}
+
+int
+openOk(const char*, int, ...)
+{
+    return 3;
+}
+
+int
+dupFail(int)
+{
+    errno = EBADF;
+    return -1;
+}
+int
+dupOk(int)
+{
+    return 2;
+}
+
+} // namespace
+
+namespace inputleap {
+// defined in ArchDaemonUnix.cpp
+void
+setArchDaemonUnixHooks(pid_t (*)(),
+                       int (*)(),
+                       int (*)(const char*, int, ...),
+                       int (*)(int),
+                       int (*)(const char*),
+                       int (*)(int));
+}
+
+class ArchDaemonUnixTest : public ::testing::Test
+{
+  protected:
+    void TearDown() override
+    {
+        inputleap::setArchDaemonUnixHooks(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    }
+};
+
+TEST_F(ArchDaemonUnixTest, setsidFailureThrows)
+{
+    ArchDaemonUnix daemon;
+    inputleap::setArchDaemonUnixHooks(forkStub, setsidFail, openOk, dupOk, chdirOk, closeStub);
+    EXPECT_THROW(daemon.daemonize("name", dummyFunc), XArchDaemonFailed);
+}
+
+TEST_F(ArchDaemonUnixTest, chdirFailureThrows)
+{
+    ArchDaemonUnix daemon;
+    inputleap::setArchDaemonUnixHooks(forkStub, setsidOk, openOk, dupOk, chdirFail, closeStub);
+    EXPECT_THROW(daemon.daemonize("name", dummyFunc), XArchDaemonFailed);
+}
+
+TEST_F(ArchDaemonUnixTest, openFailureThrows)
+{
+    ArchDaemonUnix daemon;
+    inputleap::setArchDaemonUnixHooks(forkStub, setsidOk, openFail, dupOk, chdirOk, closeStub);
+    EXPECT_THROW(daemon.daemonize("name", dummyFunc), XArchDaemonFailed);
+}
+
+TEST_F(ArchDaemonUnixTest, openSecondFailureThrows)
+{
+    ArchDaemonUnix daemon;
+    openFailSecondCount = 0;
+    inputleap::setArchDaemonUnixHooks(
+      forkStub, setsidOk, openFailSecond, dupOk, chdirOk, closeStub);
+    EXPECT_THROW(daemon.daemonize("name", dummyFunc), XArchDaemonFailed);
+}
+
+TEST_F(ArchDaemonUnixTest, dupFailureThrows)
+{
+    ArchDaemonUnix daemon;
+    inputleap::setArchDaemonUnixHooks(forkStub, setsidOk, openOk, dupFail, chdirOk, closeStub);
+    EXPECT_THROW(daemon.daemonize("name", dummyFunc), XArchDaemonFailed);
+}


### PR DESCRIPTION
## Summary
- abort daemon initialization when setsid, chdir, open, or dup fail
- allow tests to hook low level system calls
- cover daemonization failure paths with new unit tests

## Testing
- `cmake --build build --target arch -j2`
- `cmake --build build --target unittests -j2` *(fails: ‘EventType’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_b_68b621b80034832580953c3a528bd1ee