### PR TITLE
build: guard against cleaning repository root

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -57,7 +57,15 @@ fi
 REPO_ROOT=$(pwd -P)
 B_BUILD_DIR_ABS=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$B_BUILD_DIR")
 
+
+# Validate that the build directory resides within the repository and is
+# not the repository root itself.  This guards against accidental deletion
+# of arbitrary paths when cleaning the build directory.
 case "$B_BUILD_DIR_ABS" in
+    "$REPO_ROOT")
+        echo "ERROR: B_BUILD_DIR '$B_BUILD_DIR' is the repository root" >&2
+        exit 1
+        ;;
     "$REPO_ROOT"/*)
         ;;
     *)


### PR DESCRIPTION
## Summary
- ensure clean_build.sh refuses to operate if build directory is the repository root
- keep cleaning logic safe by verifying build directory lives within repo

## Testing
- `shellcheck clean_build.sh`
- `B_BUILD_DIR="test dir" B_CMAKE=true ./clean_build.sh`
- `B_BUILD_DIR="/tmp/bad dir" B_CMAKE=true ./clean_build.sh` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_b_68b62747de688325991c54e5eac3f237