### PR TITLE
Use IPC events for connection state

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -253,6 +253,7 @@ if(INPUTLEAP_BUILD_TESTS)
         test/KeySequenceTests.cpp
         test/HotkeyTests.cpp
         test/IpcClientTests.cpp
+        test/IpcStateTests.cpp
         test/main.cpp
     )
 

--- a/src/gui/src/Ipc.cpp
+++ b/src/gui/src/Ipc.cpp
@@ -22,5 +22,6 @@
 
 const char*                kIpcMsgHello        = "IHEL%1i";
 const char*                kIpcMsgLogLine        = "ILOG%s";
+const char*                kIpcMsgConnectionState = "ICST%1i";
 const char*                kIpcMsgCommand        = "ICMD%s%1i";
 const char*                kIpcMsgShutdown        = "ISDN";

--- a/src/gui/src/Ipc.h
+++ b/src/gui/src/Ipc.h
@@ -26,6 +26,7 @@
 enum qIpcMessageType {
     kIpcHello,
     kIpcLogLine,
+    kIpcConnectionState,
     kIpcCommand,
     kIpcShutdown,
 };
@@ -38,5 +39,6 @@ enum qIpcClientType {
 
 extern const char*        kIpcMsgHello;
 extern const char*        kIpcMsgLogLine;
+extern const char*        kIpcMsgConnectionState;
 extern const char*        kIpcMsgCommand;
 extern const char*        kIpcMsgShutdown;

--- a/src/gui/src/IpcClient.cpp
+++ b/src/gui/src/IpcClient.cpp
@@ -39,6 +39,7 @@ m_Enabled(false)
 
     m_Reader = new IpcReader(m_Socket);
     connect(m_Reader, &IpcReader::readLogLine, this, &IpcClient::handleReadLogLine);
+    connect(m_Reader, &IpcReader::connectionStateChanged, this, &IpcClient::connectionStateChanged);
 }
 
 IpcClient::~IpcClient()

--- a/src/gui/src/IpcClient.h
+++ b/src/gui/src/IpcClient.h
@@ -23,6 +23,7 @@
 #include <QtEndian>
 
 #include "ElevateMode.h"
+#include "AppConnectionState.h"
 
 class QTcpSocket;
 class IpcReader;
@@ -74,6 +75,7 @@ Q_SIGNALS:
     void readLogLine(const QString& text);
     void infoMessage(const QString& text);
     void errorMessage(const QString& text);
+    void connectionStateChanged(AppConnectionState state);
 
 private:
     QTcpSocket* m_Socket;

--- a/src/gui/src/IpcReader.cpp
+++ b/src/gui/src/IpcReader.cpp
@@ -78,6 +78,12 @@ void IpcReader::read()
 
             Q_EMIT readLogLine(line);
         }
+        else if (memcmp(codeBuf, kIpcMsgConnectionState, 4) == 0) {
+            char stateBuf[1];
+            readStream(stateBuf, 1);
+            AppConnectionState state = static_cast<AppConnectionState>(stateBuf[0]);
+            Q_EMIT connectionStateChanged(state);
+        }
         else {
             IPC_LOG(std::cerr << "aborting, message invalid" << std::endl);
             return;

--- a/src/gui/src/IpcReader.h
+++ b/src/gui/src/IpcReader.h
@@ -20,6 +20,7 @@
 
 #include <QObject>
 #include <QMutex>
+#include "AppConnectionState.h"
 
 class QTcpSocket;
 
@@ -35,6 +36,7 @@ public:
 
 Q_SIGNALS:
     void readLogLine(const QString& text);
+    void connectionStateChanged(AppConnectionState state);
 
 private:
     bool readStream(char* buffer, int length);

--- a/src/gui/src/MainWindow.cpp
+++ b/src/gui/src/MainWindow.cpp
@@ -156,6 +156,7 @@ MainWindow::MainWindow(QSettings& settings, AppConfig& appConfig) :
     connect(&m_IpcClient, &IpcClient::readLogLine, this, &MainWindow::appendLogRaw);
     connect(&m_IpcClient, &IpcClient::errorMessage, this, &MainWindow::appendLogError);
     connect(&m_IpcClient, &IpcClient::infoMessage, this, &MainWindow::appendLogInfo);
+    connect(&m_IpcClient, &IpcClient::connectionStateChanged, this, &MainWindow::set_connection_state);
     m_IpcClient.connectToHost();
 #endif
 
@@ -446,36 +447,7 @@ void MainWindow::appendLogRaw(const QString& text)
     for (const auto& line : lines) {
         if (!line.isEmpty()) {
             m_pLogWindow->appendRaw(line);
-            updateFromLogLine(line);
-        }
-    }
-}
-
-void MainWindow::updateFromLogLine(const QString &line)
-{
-    // TODO: this code makes Andrew cry
-    checkConnected(line);
-    checkFingerprint(line);
-}
-
-void MainWindow::checkConnected(const QString& line)
-{
-    // TODO: implement ipc connection state messages to replace this hack.
-    if (line.contains("started server") ||
-        line.contains("connected to server") ||
-        line.contains("server status: active"))
-    {
-        set_connection_state(AppConnectionState::CONNECTED);
-
-        if (!appConfig().startedBefore() && isVisible()) {
-                QMessageBox::information(
-                    this, "InputLeap",
-                    tr("InputLeap is now connected. You can close the "
-                    "config window and InputLeap will remain connected in "
-                    "the background."));
-
-            appConfig().setStartedBefore(true);
-            appConfig().saveSettings();
+            checkFingerprint(line);
         }
     }
 }
@@ -968,6 +940,15 @@ void MainWindow::set_connection_state(AppConnectionState state)
     set_icon(state);
 
     connection_state_ = state;
+
+    if (state == AppConnectionState::CONNECTED && !appConfig().startedBefore() && isVisible()) {
+        QMessageBox::information(
+            this, "InputLeap",
+            tr("InputLeap is now connected. You can close the config window and InputLeap will remain connected in the background."));
+
+        appConfig().setStartedBefore(true);
+        appConfig().saveSettings();
+    }
 }
 
 void MainWindow::setVisible(bool visible)

--- a/src/gui/src/MainWindow.h
+++ b/src/gui/src/MainWindow.h
@@ -143,7 +143,6 @@ public slots:
         bool clientArgs(QStringList& args, QString& app);
         bool serverArgs(QStringList& args, QString& app);
         void setStatus(const QString& status);
-        void updateFromLogLine(const QString& line);
         QString getIPAddresses();
         void stopService();
         void stopDesktop();
@@ -158,7 +157,6 @@ public slots:
         bool isBonjourRunning();
         void downloadBonjour();
         void promptAutoConfig();
-        void checkConnected(const QString& line);
         void checkFingerprint(const QString& line);
         void restart_cmd_app();
         void proofreadInfo();

--- a/src/gui/test/IpcStateTests.cpp
+++ b/src/gui/test/IpcStateTests.cpp
@@ -1,0 +1,56 @@
+/*  InputLeap -- mouse and keyboard sharing utility
+    Copyright (C) 2024
+
+    This package is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    found in the file LICENSE that should have accompanied this file.
+
+    This package is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define private public
+#include "../src/IpcReader.h"
+#undef private
+
+#include <gtest/gtest.h>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QCoreApplication>
+
+TEST(IpcStateTests, EmitsConnectionStateSignal)
+{
+    int argc = 0;
+    char** argv = nullptr;
+    QCoreApplication app(argc, argv);
+
+    QTcpServer server;
+    ASSERT_TRUE(server.listen(QHostAddress::LocalHost));
+    QTcpSocket client;
+    client.connectToHost(QHostAddress::LocalHost, server.serverPort());
+    ASSERT_TRUE(client.waitForConnected(1000));
+    ASSERT_TRUE(server.waitForNewConnection(1000));
+    QTcpSocket* serverConn = server.nextPendingConnection();
+    ASSERT_NE(serverConn, nullptr);
+
+    IpcReader reader(&client);
+    bool got = false;
+    AppConnectionState received = AppConnectionState::DISCONNECTED;
+    QObject::connect(&reader, &IpcReader::connectionStateChanged,
+                     [&](AppConnectionState state){ got = true; received = state; });
+
+    QByteArray data("ICST", 4);
+    data.append(static_cast<char>(AppConnectionState::CONNECTED));
+    serverConn->write(data);
+    serverConn->flush();
+    ASSERT_TRUE(client.waitForReadyRead(1000));
+    reader.read();
+
+    EXPECT_TRUE(got);
+    EXPECT_EQ(received, AppConnectionState::CONNECTED);
+}

--- a/src/lib/inputleap/App.cpp
+++ b/src/lib/inputleap/App.cpp
@@ -213,6 +213,15 @@ App::cleanupIpcClient()
 }
 
 void
+App::sendConnectionState(std::uint8_t state)
+{
+    if (m_ipcClient != nullptr) {
+        IpcConnectionStateMessage msg(state);
+        m_ipcClient->send(msg);
+    }
+}
+
+void
 App::handle_ipc_message(const Event& e)
 {
     const auto& m = e.get_data_as<IpcMessage>();

--- a/src/lib/inputleap/App.h
+++ b/src/lib/inputleap/App.h
@@ -108,6 +108,7 @@ class App : public IApp
   protected:
     void initIpcClient();
     void cleanupIpcClient();
+    void sendConnectionState(std::uint8_t state);
     void run_events_loop();
 
     IArchTaskBarReceiver* m_taskBarReceiver;

--- a/src/lib/inputleap/ClientApp.cpp
+++ b/src/lib/inputleap/ClientApp.cpp
@@ -36,6 +36,7 @@
 #include "inputleap/Screen.h"
 #include "inputleap/XScreen.h"
 #include "inputleap/protocol_types.h"
+#include "ipc/AppConnectionState.h"
 #include "mt/Thread.h"
 #include "net/NetworkAddress.h"
 #include "net/SocketMultiplexer.h"
@@ -269,6 +270,7 @@ ClientApp::handle_client_connected()
     // using CLOG_PRINT here allows the GUI to see that the client is connected
     // regardless of which log level is set
     LOG_PRINT("connected to server");
+    sendConnectionState(static_cast<std::uint8_t>(AppConnectionState::CONNECTED));
     resetRestartTimeout();
     updateStatus();
 }
@@ -294,6 +296,7 @@ void
 ClientApp::handle_client_disconnected()
 {
     LOG_NOTE("disconnected from server");
+    sendConnectionState(static_cast<std::uint8_t>(AppConnectionState::DISCONNECTED));
     if (!args().m_restartable) {
         m_events->add_event(EventType::QUIT);
     } else if (!m_suspended) {

--- a/src/lib/inputleap/ServerApp.cpp
+++ b/src/lib/inputleap/ServerApp.cpp
@@ -33,6 +33,7 @@
 #include "inputleap/ServerArgs.h"
 #include "inputleap/ServerTaskBarReceiver.h"
 #include "inputleap/XScreen.h"
+#include "ipc/AppConnectionState.h"
 #include "net/SocketMultiplexer.h"
 #include "net/TCPSocketFactory.h"
 #include "net/XSocket.h"
@@ -355,6 +356,7 @@ ServerApp::stopServer()
         server_.reset();
         m_listener = nullptr;
         m_serverState = kInitialized;
+        sendConnectionState(static_cast<std::uint8_t>(AppConnectionState::DISCONNECTED));
     } else if (m_serverState == kStarting) {
         stopRetryTimer();
         m_serverState = kInitialized;
@@ -551,6 +553,7 @@ ServerApp::startServer()
         // using CLOG_PRINT here allows the GUI to see that the server is started
         // regardless of which log level is set
         LOG_PRINT("started server (%s), waiting for clients", family);
+        sendConnectionState(static_cast<std::uint8_t>(AppConnectionState::CONNECTED));
         m_serverState = kStarted;
         return true;
     } catch (XSocketAddressInUse& e) {

--- a/src/lib/inputleap/win32/DaemonApp.cpp
+++ b/src/lib/inputleap/win32/DaemonApp.cpp
@@ -354,6 +354,9 @@ void DaemonApp::handle_ipc_message(const Event& e)
 
             m_ipcLogOutputter->notifyBuffer();
             break;
+        case kIpcConnectionState:
+            m_ipcServer->send(m, kIpcClientGui);
+            break;
     }
 }
 

--- a/src/lib/ipc/AppConnectionState.h
+++ b/src/lib/ipc/AppConnectionState.h
@@ -1,7 +1,6 @@
 /*
  * InputLeap -- mouse and keyboard sharing utility
- * Copyright (C) 2012-2016 Symless Ltd.
- * Copyright (C) 2012 Nick Bolton
+ * Copyright (C) InputLeap contributors
  *
  * This package is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,10 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ipc/Ipc.h"
+#pragma once
 
-const char*                kIpcMsgHello        = "IHEL%1i";
-const char*                kIpcMsgLogLine        = "ILOG%s";
-const char*                kIpcMsgConnectionState = "ICST%1i";
-const char*                kIpcMsgCommand        = "ICMD%s%1i";
-const char*                kIpcMsgShutdown        = "ISDN";
+#include <cstdint>
+
+enum class AppConnectionState : std::uint8_t {
+    DISCONNECTED = 0,
+    CONNECTING = 1,
+    CONNECTED = 2,
+    TRANSFERRING = 3
+};

--- a/src/lib/ipc/Ipc.h
+++ b/src/lib/ipc/Ipc.h
@@ -24,6 +24,7 @@
 enum EIpcMessage {
     kIpcHello,
     kIpcLogLine,
+    kIpcConnectionState,
     kIpcCommand,
     kIpcShutdown,
 };
@@ -41,6 +42,10 @@ extern const char*        kIpcMsgHello;
 // log line: daemon -> gui
 // $1 = aggregate log lines collected from input-leaps/c or the daemon itself.
 extern const char*        kIpcMsgLogLine;
+
+// connection state: node -> daemon -> gui
+// $1 = numeric connection state value.
+extern const char*        kIpcMsgConnectionState;
 
 // command: gui -> daemon
 // $1 = command; the command for the daemon to launch, typically the full

--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -90,6 +90,11 @@ void IpcClientProxy::handle_data()
         else if (memcmp(code, kIpcMsgCommand, 4) == 0) {
             event_data = create_event_data<IpcCommandMessage>(parseCommand());
         }
+        else if (memcmp(code, kIpcMsgConnectionState, 4) == 0) {
+            std::uint8_t state;
+            ProtocolUtil::readf(stream_.get(), kIpcMsgConnectionState + 4, &state);
+            event_data = create_event_data<IpcConnectionStateMessage>(IpcConnectionStateMessage(state));
+        }
         else {
             LOG_ERR("invalid ipc message");
             disconnect();
@@ -118,6 +123,12 @@ IpcClientProxy::send(const IpcMessage& message)
         const IpcLogLineMessage& llm = static_cast<const IpcLogLineMessage&>(message);
         const std::string logLine = llm.logLine();
         ProtocolUtil::writef(stream_.get(), kIpcMsgLogLine, &logLine);
+        break;
+    }
+
+    case kIpcConnectionState: {
+        const IpcConnectionStateMessage& sm = static_cast<const IpcConnectionStateMessage&>(message);
+        ProtocolUtil::writef(stream_.get(), kIpcMsgConnectionState, sm.state());
         break;
     }
 

--- a/src/lib/ipc/IpcClientProxy.h
+++ b/src/lib/ipc/IpcClientProxy.h
@@ -32,6 +32,7 @@ namespace inputleap {
 class IpcMessage;
 class IpcCommandMessage;
 class IpcHelloMessage;
+class IpcConnectionStateMessage;
 class IStream;
 
 class IpcClientProxy : public EventTarget {

--- a/src/lib/ipc/IpcMessage.cpp
+++ b/src/lib/ipc/IpcMessage.cpp
@@ -49,6 +49,16 @@ IpcShutdownMessage::~IpcShutdownMessage()
 {
 }
 
+IpcConnectionStateMessage::IpcConnectionStateMessage(std::uint8_t state) :
+    IpcMessage(kIpcConnectionState),
+    state_(state)
+{
+}
+
+IpcConnectionStateMessage::~IpcConnectionStateMessage()
+{
+}
+
 IpcLogLineMessage::IpcLogLineMessage(const std::string& logLine) :
     IpcMessage(kIpcLogLine),
     m_logLine(logLine)

--- a/src/lib/ipc/IpcMessage.h
+++ b/src/lib/ipc/IpcMessage.h
@@ -57,6 +57,17 @@ public:
     virtual ~IpcShutdownMessage();
 };
 
+class IpcConnectionStateMessage : public IpcMessage {
+public:
+    explicit IpcConnectionStateMessage(std::uint8_t state);
+    virtual ~IpcConnectionStateMessage();
+
+    std::uint8_t state() const { return state_; }
+
+private:
+    std::uint8_t state_;
+};
+
 
 class IpcLogLineMessage : public IpcMessage {
 public:

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -54,6 +54,9 @@ void IpcServerProxy::handle_data()
         if (memcmp(code, kIpcMsgLogLine, 4) == 0) {
             event_data = create_event_data<IpcLogLineMessage>(parseLogLine());
         }
+        else if (memcmp(code, kIpcMsgConnectionState, 4) == 0) {
+            event_data = create_event_data<IpcConnectionStateMessage>(parseConnectionState());
+        }
         else if (memcmp(code, kIpcMsgShutdown, 4) == 0) {
             event_data = create_event_data<IpcShutdownMessage>(IpcShutdownMessage{});
         }
@@ -89,6 +92,12 @@ IpcServerProxy::send(const IpcMessage& message)
         break;
     }
 
+    case kIpcConnectionState: {
+        const IpcConnectionStateMessage& sm = static_cast<const IpcConnectionStateMessage&>(message);
+        ProtocolUtil::writef(&m_stream, kIpcMsgConnectionState, sm.state());
+        break;
+    }
+
     default:
         LOG_ERR("ipc message not supported: %d", message.type());
         break;
@@ -102,6 +111,13 @@ IpcLogLineMessage IpcServerProxy::parseLogLine()
 
     // must be deleted by event handler.
     return IpcLogLineMessage(logLine);
+}
+
+IpcConnectionStateMessage IpcServerProxy::parseConnectionState()
+{
+    std::uint8_t state;
+    ProtocolUtil::readf(&m_stream, kIpcMsgConnectionState + 4, &state);
+    return IpcConnectionStateMessage(state);
 }
 
 void

--- a/src/lib/ipc/IpcServerProxy.h
+++ b/src/lib/ipc/IpcServerProxy.h
@@ -28,6 +28,7 @@ namespace inputleap {
 class IStream;
 class IpcMessage;
 class IpcLogLineMessage;
+class IpcConnectionStateMessage;
 
 class IpcServerProxy : public EventTarget {
     friend class IpcClient;
@@ -41,6 +42,7 @@ private:
 
     void handle_data();
     IpcLogLineMessage parseLogLine();
+    IpcConnectionStateMessage parseConnectionState();
     void disconnect();
 
 private:


### PR DESCRIPTION
## Summary
- add kIpcConnectionState message and propagation through IPC layer
- update GUI to handle connection state events instead of parsing logs
- test IPC reader for connection state notification

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_TESTS=ON` *(fails: Cannot find gtest sources)*


------
https://chatgpt.com/codex/tasks/task_b_68b629a31edc8325baf5437e9b651ab4