### PR TITLE
Check client type before closing

### DIFF
--- a/doc/newsfragments/dynamic-client-close.bugfix
+++ b/doc/newsfragments/dynamic-client-close.bugfix
@@ -1,0 +1,2 @@
+Use dynamic_cast when closing clients to ensure correct type and log an error if the cast fails.
+

--- a/src/lib/server/Server.cpp
+++ b/src/lib/server/Server.cpp
@@ -2078,9 +2078,14 @@ Server::closeClient(BaseClientProxy* client, const char* msg)
 	// client.
 	LOG_NOTE("disconnecting client \"%s\"", getName(client).c_str());
 
-	// send message
-	// FIXME -- avoid type cast (kinda hard, though)
-    (static_cast<ClientProxy*>(client))->close(msg);
+        // send message
+        // FIXME -- avoid type cast (kinda hard, though)
+        if (auto* clientProxy = dynamic_cast<ClientProxy*>(client)) {
+            clientProxy->close(msg);
+        }
+        else {
+            LOG_ERR("client \"%s\" is not a ClientProxy; skipping close", getName(client).c_str());
+        }
 
 	// install timer.  wait timeout seconds for client to close.
 	double timeout = 5.0;


### PR DESCRIPTION
## Summary
- use dynamic_cast in Server::closeClient
- log an error and skip closing if the cast fails
- add release note

## Testing
- `cmake -S . -B build -DINPUTLEAP_BUILD_GUI=OFF`
- `cmake --build build` *(fails: interrupt at ~41%)*
- `ctest --test-dir build` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_b_68b64712e47483259e4386f9906b38a8